### PR TITLE
Fix import cycle and ensure options are applied in media_cover integration

### DIFF
--- a/custom_components/media_cover_art/__init__.py
+++ b/custom_components/media_cover_art/__init__.py
@@ -23,7 +23,8 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .cover_resolver import async_resolve_cover, TrackQuery
+from .cover_resolver import async_resolve_cover
+from .models import TrackQuery
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,12 +62,14 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self.entry = entry
         self.source_entity_id: str = entry.data[CONF_SOURCE_ENTITY_ID]
-        self.providers: list[str] = list(entry.data.get(CONF_PROVIDERS, DEFAULT_PROVIDERS))
-        self.artwork_size: int = int(entry.data.get(CONF_ARTWORK_SIZE, DEFAULT_ARTWORK_SIZE))
+        self.providers: list[str] = []
+        self.artwork_size: int = DEFAULT_ARTWORK_SIZE
 
         self._session = aiohttp_client.async_get_clientsession(hass)
         self._unsub_state_change: Any | None = None
         self._lock = asyncio.Lock()
+
+        self._update_from_entry(entry)
 
         self._artist: str | None = None
         self._title: str | None = None
@@ -80,6 +83,14 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
             update_method=self._async_update_data,
             update_interval=None,  # event-driven
         )
+
+    def _update_from_entry(self, entry: ConfigEntry) -> None:
+        providers = entry.options.get(CONF_PROVIDERS, entry.data.get(CONF_PROVIDERS, DEFAULT_PROVIDERS))
+        self.providers = list(providers) if isinstance(providers, list) else list(DEFAULT_PROVIDERS)
+
+        artwork_size = entry.options.get(CONF_ARTWORK_SIZE, entry.data.get(CONF_ARTWORK_SIZE, DEFAULT_ARTWORK_SIZE))
+        self.artwork_size = int(artwork_size)
+
 
     async def async_start(self) -> None:
         """Start listening to media_player state changes and do initial refresh."""
@@ -210,9 +221,15 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
             )
 
 
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = CoverCoordinator(hass, entry)
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
 
     await coordinator.async_start()
 

--- a/custom_components/media_cover_art/cover_resolver.py
+++ b/custom_components/media_cover_art/cover_resolver.py
@@ -1,31 +1,13 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
 from typing import Iterable
 
-from homeassistant.exceptions import HomeAssistantError
-
 from .const import PROVIDER_ITUNES
 from .itunes import async_itunes_resolve
+from .models import ResolvedCover, TrackQuery
 
 _LOGGER = logging.getLogger(__name__)
-
-
-@dataclass(slots=True)
-class TrackQuery:
-    artist: str | None
-    title: str | None
-    album: str | None
-    artwork_size: int
-
-
-@dataclass(slots=True)
-class ResolvedCover:
-    provider: str
-    artwork_url: str | None
-    content_type: str
-    image: bytes
 
 
 async def async_resolve_cover(*, session, query: TrackQuery, providers: Iterable[str]) -> ResolvedCover | None:

--- a/custom_components/media_cover_art/itunes.py
+++ b/custom_components/media_cover_art/itunes.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
 from typing import Any
 
 from homeassistant.exceptions import HomeAssistantError
 
-from .cover_resolver import ResolvedCover, TrackQuery
+from .models import ResolvedCover, TrackQuery
 
 ITUNES_SEARCH_URL = "https://itunes.apple.com/search"
 

--- a/custom_components/media_cover_art/models.py
+++ b/custom_components/media_cover_art/models.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class TrackQuery:
+    artist: str | None
+    title: str | None
+    album: str | None
+    artwork_size: int
+
+
+@dataclass(slots=True)
+class ResolvedCover:
+    provider: str
+    artwork_url: str | None
+    content_type: str
+    image: bytes


### PR DESCRIPTION
### Motivation
- Prevent a startup import cycle caused by shared dataclasses being split across modules which could break integration loading. 
- Ensure `providers` and `artwork_size` from the integration options take effect without requiring manual restart. 

### Description
- Extracted shared dataclasses `TrackQuery` and `ResolvedCover` into a new `models.py` and updated imports in `cover_resolver.py` and `itunes.py` to remove the circular dependency. 
- Changed the coordinator to initialize `providers` and `artwork_size` from `entry.options` (with fallback to `entry.data`) via a new `_update_from_entry` method. 
- Added a config-entry update listener (`entry.add_update_listener`) that reloads the entry so option changes apply immediately. 
- Minor cleanup to imports and ensured all modules compile together. 

### Testing
- Ran `python -m compileall custom_components/media_cover_art` and the compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b02ea35ac8320a74819ac2b1854e7)