### PR TITLE
feat: staged remix fallback, en.json translation, icon & HACS metadata

### DIFF
--- a/custom_components/media_cover_art/cover_resolver.py
+++ b/custom_components/media_cover_art/cover_resolver.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import replace
 from typing import Iterable
 
 from .const import PROVIDER_ITUNES, PROVIDER_MUSICBRAINZ
@@ -11,14 +12,13 @@ from .musicbrainz import async_musicbrainz_resolve
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_resolve_cover(*, session, query: TrackQuery, providers: Iterable[str]) -> ResolvedCover | None:
-    """Try providers in order and return first match."""
-    provider_list = [p for p in providers if isinstance(p, str)]
-    if not provider_list:
-        provider_list = [PROVIDER_ITUNES]
-
-    last_err: Exception | None = None
-
+async def _try_providers(
+    *,
+    session,
+    query: TrackQuery,
+    provider_list: list[str],
+) -> ResolvedCover | None:
+    """Try each provider once with the given query. Returns first match or None."""
     for provider in provider_list:
         try:
             if provider == PROVIDER_ITUNES:
@@ -36,10 +36,39 @@ async def async_resolve_cover(*, session, query: TrackQuery, providers: Iterable
             _LOGGER.debug("Unknown provider '%s' (skipping)", provider)
 
         except Exception as err:  # noqa: BLE001
-            last_err = err
-            _LOGGER.debug("Provider '%s' failed: %s", provider, err)
+            _LOGGER.debug("Provider '%s' failed (title=%r): %s", provider, query.title, err)
 
-    if last_err:
-        _LOGGER.debug("All providers failed, last error: %s", last_err)
+    return None
 
+
+async def async_resolve_cover(*, session, query: TrackQuery, providers: Iterable[str]) -> ResolvedCover | None:
+    """Resolve cover art with a staged title fallback strategy.
+
+    Stage 1 – original title (e.g. "Song (Remix)"): lets providers find a
+              remix-specific cover if one exists.
+    Stage 2 – cleaned title (e.g. "Song"): strips remix/edit annotations and
+              retries so the original release cover is used as a fallback.
+
+    Returns the first successful result or None (callers should show the
+    default fallback logo in that case).
+    """
+    provider_list = [p for p in providers if isinstance(p, str)]
+    if not provider_list:
+        provider_list = [PROVIDER_ITUNES]
+
+    # Build the ordered list of title variants to try.
+    # original_title is set only when it differs from the cleaned title.
+    if query.original_title and query.original_title != query.title:
+        title_stages: list[str | None] = [query.original_title, query.title]
+    else:
+        title_stages = [query.title]
+
+    for stage_title in title_stages:
+        stage_query = replace(query, title=stage_title, original_title=None) if stage_title != query.title else query
+        _LOGGER.debug("Cover search stage title=%r", stage_title)
+        resolved = await _try_providers(session=session, query=stage_query, provider_list=provider_list)
+        if resolved:
+            return resolved
+
+    _LOGGER.debug("All stages exhausted – no cover found for artist=%r title=%r", query.artist, query.title)
     return None

--- a/custom_components/media_cover_art/manifest.json
+++ b/custom_components/media_cover_art/manifest.json
@@ -9,6 +9,7 @@
   ],
   "config_flow": true,
   "iot_class": "cloud_polling",
+  "icon": "icon.svg",
   "dependencies": [],
   "requirements": []
 }

--- a/custom_components/media_cover_art/models.py
+++ b/custom_components/media_cover_art/models.py
@@ -10,6 +10,7 @@ class TrackQuery:
     album: str | None
     artwork_width: int
     artwork_height: int
+    original_title: str | None = None  # raw title before remix/edit stripping
 
 
 @dataclass(slots=True)

--- a/custom_components/media_cover_art/translations/de.json
+++ b/custom_components/media_cover_art/translations/de.json
@@ -3,17 +3,17 @@
     "step": {
       "user": {
         "title": "Media Cover Art",
-        "description": "Select a media player. Cover art will be resolved from media_artist + media_title.",
+        "description": "Wähle einen Media Player aus. Cover Art wird anhand von media_artist + media_title ermittelt.",
         "data": {
-          "source_entity_id": "Media player",
-          "providers": "Cover sources",
-          "artwork_width": "Artwork width (px)",
-          "artwork_height": "Artwork height (px)"
+          "source_entity_id": "Media Player",
+          "providers": "Cover-Quellen",
+          "artwork_width": "Artwork-Breite (px)",
+          "artwork_height": "Artwork-Höhe (px)"
         }
       }
     },
     "abort": {
-      "already_configured": "This media player is already configured."
+      "already_configured": "Dieser Media Player ist bereits konfiguriert."
     }
   }
 }

--- a/custom_components/media_cover_art/translations/en.json
+++ b/custom_components/media_cover_art/translations/en.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Media Cover Art",
+        "description": "Select a media player. Cover art will be resolved from media_artist + media_title.",
+        "data": {
+          "source_entity_id": "Media player",
+          "providers": "Cover sources",
+          "artwork_width": "Artwork width (px)",
+          "artwork_height": "Artwork height (px)"
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "This media player is already configured."
+    }
+  }
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
   "name": "Media Cover Art",
-  "hide_default_branch": true
+  "hide_default_branch": true,
+  "render_readme": true,
+  "homeassistant": "2023.1.0"
 }


### PR DESCRIPTION
- cover_resolver: two-stage title search – try original title first (e.g. "Song (Remix)") then fall back to cleaned title ("Song") so remix-specific covers are used when available, with the original release cover as an automatic fallback
- __init__: add _raw_text() helper; store _raw_title; build track key from raw title so remix and original are treated as distinct tracks and each triggers its own cover fetch
- models: add optional `original_title` field to TrackQuery
- translations/en.json: create missing English translation file (HA requires this as the canonical locale next to strings.json)
- translations/de.json: replace placeholder English text with actual German translations
- manifest.json: add "icon" field pointing to icon.svg
- hacs.json: add render_readme and minimum HA version metadata

https://claude.ai/code/session_01E3DoXWJW6Vk1CT1Fu6eeEt