### PR TITLE
Refactor: Extract shared helpers and optimize regex compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.2.2 (2026-02-24)
+- Gemeinsamen Code (`FALLBACK_IMAGE`, `source_name`) aus `image.py` und `camera.py` in neue Datei `helpers.py` ausgelagert (Duplikation beseitigt)
+- `itunes.py`: Vier Regex-Muster in `_clean()` auf Modulebene vorkompiliert statt bei jedem Aufruf neu zu kompilieren
+- `musicbrainz.py`: Debug-Logging bei fehlgeschlagenem Artwork-Download hinzugefügt (statt stilles `return None`)
+- `musicbrainz.py`: User-Agent-Header auf aktuelle Version angepasst (`0.2.2`)
+
+## 0.2.1 (2026-02-23)
+- Staged Remix Fallback: Erst Remix-spezifisches Cover suchen, dann Original-Release als Fallback
+- MusicBrainz als zweiter Provider hinzugefügt (Cover Art Archive)
+- Camera-Entity für bessere Lovelace-Kompatibilität
+- Status-Sensor mit Diagnostik-Attributen
+- Konfigurierbare Artwork-Dimensionen (Breite/Höhe getrennt)
+- Englische und deutsche Übersetzungen
+- HACS-Metadaten und Icon
+
 ## 0.1.0 (2026-02-22)
 - Initiale Version
 - Image-Entity für Cover-Art aus `media_artist` + `media_title`

--- a/custom_components/media_cover_art/camera.py
+++ b/custom_components/media_cover_art/camera.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 from typing import Any
 
 from homeassistant.components.camera import Camera
@@ -10,15 +9,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import CoverCoordinator, CoverData
 from .const import DOMAIN
-
-_FALLBACK_IMAGE = base64.b64decode(
-    "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABQUlEQVR42u3cMRGAMAAEwVeSGglowAqKcBY3QQAVM+l+izPAb8NAkvN6lnqLhwCABwGAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAO1vz/h0ApcM3QYjhuyHE+N0IYvhuCDF+N4IYvxsBAAAYvxlBjN+NAAAAjN+MAAAAjN+MAAAAAAAAAADaABxjfAIAAAAAAAAAAAAAwFsAAAAAAAAAAAAAga+BAAAAgT+CAAAAAn8FQ+BcAAAAQOBsoNPBALgfAAA3hADgjiAA3BIGgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQNt6Adpn9COM5b1AAAAAAElFTkSuQmCC"
-)
-
-
-def _source_name(source_entity_id: str) -> str:
-    object_id = source_entity_id.split(".", 1)[-1]
-    return object_id.replace("_", " ").title()
+from .helpers import FALLBACK_IMAGE, source_name
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
@@ -41,7 +32,7 @@ class MediaCoverArtCamera(CoordinatorEntity[CoverCoordinator], Camera):
             except TypeError:
                 Camera.__init__(self, hass=coordinator.hass)
         self._attr_unique_id = f"{entry.entry_id}_cover_camera"
-        self._attr_name = f"Cover {_source_name(coordinator.source_entity_id)}"
+        self._attr_name = f"Cover {source_name(coordinator.source_entity_id)}"
         self._attr_is_streaming = False
         self.content_type = "image/png"
 
@@ -49,7 +40,7 @@ class MediaCoverArtCamera(CoordinatorEntity[CoverCoordinator], Camera):
         data: CoverData | None = self.coordinator.data
         if not data or not data.image:
             self.content_type = "image/png"
-            return _FALLBACK_IMAGE
+            return FALLBACK_IMAGE
         self.content_type = data.content_type or "image/jpeg"
         return data.image
 

--- a/custom_components/media_cover_art/helpers.py
+++ b/custom_components/media_cover_art/helpers.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import base64
+
+# Shared fallback image (small PNG placeholder shown when no cover is available).
+# Used by both the Image and Camera entities to avoid duplicating the binary blob.
+FALLBACK_IMAGE = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABQUlEQVR42u3cMRGAMAAEwVeSGglowAqKcBY3QQAVM+l+izPAb8NAkvN6lnqLhwCABwGAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAO1vz/h0ApcM3QYjhuyHE+N0IYvhuCDF+N4IYvxsBAAAYvxlBjN+NAAAAjN+MAAAAjN+MAAAAAAAAAADaABxjfAIAAAAAAAAAAAAAwFsAAAAAAAAAAAAAga+BAAAAgT+CAAAAAn8FQ+BcAAAAQOBsoNPBALgfAAA3hADgjiAA3BIGgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQNt6Adpn9COM5b1AAAAAAElFTkSuQmCC"
+)
+
+
+def source_name(source_entity_id: str) -> str:
+    """Return a human-readable name derived from a media_player entity id."""
+    object_id = source_entity_id.split(".", 1)[-1]
+    return object_id.replace("_", " ").title()

--- a/custom_components/media_cover_art/image.py
+++ b/custom_components/media_cover_art/image.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import base64
 from typing import Any
 
 
@@ -11,15 +10,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import CoverCoordinator, CoverData
 from .const import DOMAIN
-
-_FALLBACK_IMAGE = base64.b64decode(
-    "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABQUlEQVR42u3cMRGAMAAEwVeSGglowAqKcBY3QQAVM+l+izPAb8NAkvN6lnqLhwCABwGAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAO1vz/h0ApcM3QYjhuyHE+N0IYvhuCDF+N4IYvxsBAAAYvxlBjN+NAAAAjN+MAAAAjN+MAAAAAAAAAADaABxjfAIAAAAAAAAAAAAAwFsAAAAAAAAAAAAAga+BAAAAgT+CAAAAAn8FQ+BcAAAAQOBsoNPBALgfAAA3hADgjiAA3BIGgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQNt6Adpn9COM5b1AAAAAAElFTkSuQmCC"
-)
-
-
-def _source_name(source_entity_id: str) -> str:
-    object_id = source_entity_id.split(".", 1)[-1]
-    return object_id.replace("_", " ").title()
+from .helpers import FALLBACK_IMAGE, source_name
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
@@ -42,7 +33,7 @@ class MediaCoverArtImage(CoordinatorEntity[CoverCoordinator], ImageEntity):
                 ImageEntity.__init__(self)
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_cover"
-        self._attr_name = f"Cover {_source_name(coordinator.source_entity_id)}"
+        self._attr_name = f"Cover {source_name(coordinator.source_entity_id)}"
         self._attr_content_type = "image/jpeg"
 
     @property
@@ -54,7 +45,7 @@ class MediaCoverArtImage(CoordinatorEntity[CoverCoordinator], ImageEntity):
         data: CoverData | None = self.coordinator.data
         if not data or not data.image:
             self._attr_content_type = "image/png"
-            return _FALLBACK_IMAGE
+            return FALLBACK_IMAGE
         self._attr_content_type = data.content_type or "image/jpeg"
         return data.image
 

--- a/custom_components/media_cover_art/itunes.py
+++ b/custom_components/media_cover_art/itunes.py
@@ -11,13 +11,19 @@ ITUNES_SEARCH_URL = "https://itunes.apple.com/search"
 _JSON_KW = {"content_type": None}
 _RE_ARTWORK_SIZE = re.compile(r"/(\d{2,4})x(\d{2,4})bb\.(jpg|png)$", re.IGNORECASE)
 
+# Pre-compiled patterns for _clean() – avoids recompilation on every call.
+_RE_PAREN_FEAT = re.compile(r"\((feat\.|featuring|remix|edit|mix).*?\)", re.IGNORECASE)
+_RE_BRACKET_FEAT = re.compile(r"\[(feat\.|featuring|remix|edit|mix).*?\]", re.IGNORECASE)
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RE_SPACES = re.compile(r"\s+")
+
 
 def _clean(s: str) -> str:
     s = s.strip().lower()
-    s = re.sub(r"\((feat\.|featuring|remix|edit|mix).*?\)", "", s, flags=re.IGNORECASE)
-    s = re.sub(r"\[(feat\.|featuring|remix|edit|mix).*?\]", "", s, flags=re.IGNORECASE)
-    s = re.sub(r"[^a-z0-9]+", " ", s)
-    s = re.sub(r"\s+", " ", s)
+    s = _RE_PAREN_FEAT.sub("", s)
+    s = _RE_BRACKET_FEAT.sub("", s)
+    s = _RE_NON_ALNUM.sub(" ", s)
+    s = _RE_SPACES.sub(" ", s)
     return s.strip()
 
 

--- a/custom_components/media_cover_art/manifest.json
+++ b/custom_components/media_cover_art/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "media_cover_art",
   "name": "Media Cover Art",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "documentation": "https://github.com/Levtos/test_art",
   "issue_tracker": "https://github.com/Levtos/test_art/issues",
   "codeowners": [

--- a/custom_components/media_cover_art/musicbrainz.py
+++ b/custom_components/media_cover_art/musicbrainz.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from homeassistant.exceptions import HomeAssistantError
 
 from .models import ResolvedCover, TrackQuery
+
+_LOGGER = logging.getLogger(__name__)
 
 MB_SEARCH_URL = "https://musicbrainz.org/ws/2/recording"
 CAA_FRONT_URL = "https://coverartarchive.org/release/{release_id}/front-500"
@@ -30,7 +33,7 @@ async def async_musicbrainz_resolve(*, session, query: TrackQuery) -> ResolvedCo
 
     headers = {
         # MusicBrainz asks for a descriptive User-Agent
-        "User-Agent": "media-cover-art-ha/0.1 (+https://github.com/Levtos/test_art)",
+        "User-Agent": "media-cover-art-ha/0.2.2 (+https://github.com/Levtos/test_art)",
     }
 
     try:
@@ -72,7 +75,8 @@ async def async_musicbrainz_resolve(*, session, query: TrackQuery) -> ResolvedCo
                 return None
             content_type = img_resp.headers.get("Content-Type", "image/jpeg")
             image = await img_resp.read()
-    except Exception:
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("MusicBrainz artwork fetch failed for %s: %s", artwork_url, err)
         return None
 
     if not image:


### PR DESCRIPTION
## Summary
This release refactors common code into a shared helpers module and optimizes performance by pre-compiling regex patterns. It also improves debugging and updates version information.

## Key Changes

- **Extract shared code to `helpers.py`**: Moved `FALLBACK_IMAGE` constant and `source_name()` function from both `image.py` and `camera.py` into a new `helpers.py` module to eliminate duplication
- **Optimize iTunes provider**: Pre-compile four regex patterns in `itunes.py` at module level instead of recompiling them on every `_clean()` call
- **Improve MusicBrainz debugging**: Added debug-level logging when artwork downloads fail instead of silently returning `None`
- **Update version information**: Bumped User-Agent header in `musicbrainz.py` to version 0.2.2 and updated `manifest.json`

## Implementation Details

- The `FALLBACK_IMAGE` base64-encoded PNG blob is now defined once in `helpers.py` and imported by both entity modules
- The `source_name()` function converts entity IDs to human-readable names and is now centralized
- Four regex patterns in `itunes.py` (`_RE_PAREN_FEAT`, `_RE_BRACKET_FEAT`, `_RE_NON_ALNUM`, `_RE_SPACES`) are compiled once at module initialization, reducing CPU overhead during track metadata cleaning
- MusicBrainz provider now logs exceptions at debug level for better troubleshooting

https://claude.ai/code/session_01RWAh4h9eFqmqAEzuNnXsCL