### PR TITLE
fix: Sensor-Platform aktivieren, available/state/media_image_hash korrigieren (v0.2.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.2.8 (2026-02-25)
+- `Platform.SENSOR` zu `PLATFORMS` hinzugefügt – Sensor-Entity wurde nie geladen, da sie fehlte
+- `available`-Property korrigiert: gibt jetzt `False` zurück wenn Quelle den State `unavailable`/`unknown` hat (statt immer `True`)
+- `state`-Property korrigiert: gibt `None` zurück wenn kein Source-State vorhanden (HA setzt dann automatisch `unavailable`)
+- `media_image_hash` verbessert: beinhaltet jetzt `last_updated`-Zeitstempel, damit der Browser-Cache invalidiert wird wenn das Cover nach dem Platzhalter nachgeladen wird
+
 ## 0.2.7 (2026-02-25)
 - `media_player`-Wrapper robuster gemacht, damit die Entität zuverlässig erzeugt wird (reduzierte Attribut-Spiegelung + defensivere Source-Attribut-Lesezugriffe)
 - Universal-Proxy-Verhalten beibehalten: Steuerung bleibt auf dem Source-Player, Cover kommt aus dem Coordinator

--- a/custom_components/media_cover_art/const.py
+++ b/custom_components/media_cover_art/const.py
@@ -4,7 +4,7 @@ from homeassistant.const import Platform
 
 DOMAIN = "media_cover_art"
 
-PLATFORMS: list[Platform] = [Platform.IMAGE, Platform.CAMERA, Platform.MEDIA_PLAYER]
+PLATFORMS: list[Platform] = [Platform.IMAGE, Platform.CAMERA, Platform.MEDIA_PLAYER, Platform.SENSOR]
 
 CONF_SOURCE_ENTITY_ID = "source_entity_id"
 CONF_PROVIDERS = "providers"

--- a/custom_components/media_cover_art/manifest.json
+++ b/custom_components/media_cover_art/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "media_cover_art",
   "name": "Media Cover Art",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "documentation": "https://github.com/Levtos/test_art",
   "issue_tracker": "https://github.com/Levtos/test_art/issues",
   "codeowners": [


### PR DESCRIPTION
- Platform.SENSOR zu PLATFORMS hinzugefügt (sensor.py wurde nie geladen)
- available-Property: gibt False zurück wenn Quelle 'unavailable'/'unknown' ist
- state-Property: gibt None zurück statt String 'unavailable' wenn kein Source-State
- media_image_hash: last_updated eingebaut damit Browser-Cache bei Cover-Nachladen busted wird

https://claude.ai/code/session_016kdKRTi7FGBWYmi4yfRzhH