### PR TITLE
fix: media_player-Entity-Erstellung und HA-Kompatibilität (v0.2.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.9 (2026-02-25)
+- `media_player.__init__`: Beide Basisklassen (`CoordinatorEntity`, `MediaPlayerEntity`) jetzt explizit initialisiert – identisches Muster wie `camera.py`/`image.py`, behebt Entitäts-Erstellungsfehler in neueren HA-Versionen
+- `state`-Property gibt jetzt `MediaPlayerState`-Enum zurück statt plain String (Kompatibilität mit HA-Validierung)
+- `sensor.py`: `_attr_has_entity_name = True` entfernt (ohne `device_info` verursacht es in HA 2024.1+ Warnungen/Fehler); Name wird jetzt in `__init__` gesetzt
+
 ## 0.2.8 (2026-02-25)
 - `Platform.SENSOR` zu `PLATFORMS` hinzugefügt – Sensor-Entity wurde nie geladen, da sie fehlte
 - `available`-Property korrigiert: gibt jetzt `False` zurück wenn Quelle den State `unavailable`/`unknown` hat (statt immer `True`)

--- a/custom_components/media_cover_art/manifest.json
+++ b/custom_components/media_cover_art/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "media_cover_art",
   "name": "Media Cover Art",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "documentation": "https://github.com/Levtos/test_art",
   "issue_tracker": "https://github.com/Levtos/test_art/issues",
   "codeowners": [

--- a/custom_components/media_cover_art/sensor.py
+++ b/custom_components/media_cover_art/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import CoverCoordinator, CoverData
 from .const import DOMAIN
+from .helpers import source_name
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
@@ -15,13 +16,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
 
 class MediaCoverArtStatusSensor(CoordinatorEntity[CoverCoordinator], SensorEntity):
-    _attr_has_entity_name = True
-    _attr_name = "Cover Status"
+    _attr_has_entity_name = False
     _attr_icon = "mdi:music-circle"
 
     def __init__(self, coordinator: CoverCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{entry.entry_id}_cover_status"
+        self._attr_name = f"{source_name(coordinator.source_entity_id)} Cover Status"
 
     @property
     def native_value(self) -> str:


### PR DESCRIPTION
- __init__: Beide Basisklassen explizit initialisiert (CoordinatorEntity + MediaPlayerEntity), identisches Muster wie camera.py/image.py; behebt "Entity kann nicht erzeugt werden" in HA-Versionen wo CoordinatorEntity kein super().__init__() mehr aufruft
- state: gibt MediaPlayerState-Enum zurück statt plain String (Kompatibilität mit HA 2024.x-Validierung die isinstance(state, MediaPlayerState) prüft)
- sensor: _attr_has_entity_name=True entfernt (ohne device_info Fehler in HA 2024.1+); Name jetzt via __init__ mit Quellenname gesetzt

https://claude.ai/code/session_016kdKRTi7FGBWYmi4yfRzhH