### PR TITLE
fix: supported_features als MediaPlayerEntityFeature zurückgeben (v0.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0 (2026-02-25)
+- `supported_features` gibt jetzt `MediaPlayerEntityFeature` (IntFlag) zurück statt `int` – behebt `TypeError: argument of type 'int' is not iterable` beim Hinzufügen der Entity (HA prüft Feature-Flags mit `in`-Operator)
+
 ## 0.2.9 (2026-02-25)
 - `media_player.__init__`: Beide Basisklassen (`CoordinatorEntity`, `MediaPlayerEntity`) jetzt explizit initialisiert – identisches Muster wie `camera.py`/`image.py`, behebt Entitäts-Erstellungsfehler in neueren HA-Versionen
 - `state`-Property gibt jetzt `MediaPlayerState`-Enum zurück statt plain String (Kompatibilität mit HA-Validierung)

--- a/custom_components/media_cover_art/manifest.json
+++ b/custom_components/media_cover_art/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "media_cover_art",
   "name": "Media Cover Art",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "documentation": "https://github.com/Levtos/test_art",
   "issue_tracker": "https://github.com/Levtos/test_art/issues",
   "codeowners": [

--- a/custom_components/media_cover_art/media_player.py
+++ b/custom_components/media_cover_art/media_player.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.media_player import MediaPlayerEntity, MediaPlayerState
+from homeassistant.components.media_player import MediaPlayerEntity, MediaPlayerEntityFeature, MediaPlayerState
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers.event import async_track_state_change_event
@@ -81,14 +81,14 @@ class MediaCoverArtUniversalPlayer(CoordinatorEntity[CoverCoordinator], MediaPla
             return None
 
     @property
-    def supported_features(self) -> int:
+    def supported_features(self) -> MediaPlayerEntityFeature:
         src = self.source_state
         if src is None:
-            return 0
+            return MediaPlayerEntityFeature(0)
         try:
-            return int(src.attributes.get("supported_features", 0))
+            return MediaPlayerEntityFeature(int(src.attributes.get("supported_features", 0)))
         except (TypeError, ValueError):
-            return 0
+            return MediaPlayerEntityFeature(0)
 
     def _source_attr(self, key: str, default: Any = None) -> Any:
         src = self.source_state


### PR DESCRIPTION
…3.0)

HA prüft Feature-Flags mit "MediaPlayerEntityFeature.X in self.supported_features". Der in-Operator erwartet IntFlag (iterierbar), kein plain int. Der bisherige Rückgabewert int verursachte "TypeError: argument of type 'int' is not iterable" beim ersten async_write_ha_state() → Entity konnte nicht hinzugefügt werden.

https://claude.ai/code/session_016kdKRTi7FGBWYmi4yfRzhH