### PR TITLE
feat(tv): add EPG lookup via TVMaze DE schedule as step 0

### DIFF
--- a/custom_components/media_art_wrapper/epg.py
+++ b/custom_components/media_art_wrapper/epg.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+TVMAZE_SCHEDULE_URL = "https://api.tvmaze.com/schedule"
+_JSON_KW = {"content_type": None}
+
+# Date-keyed cache: only the last 2 calendar days are kept.
+_schedule_cache: dict[str, list[dict[str, Any]]] = {}
+
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RE_SPACES = re.compile(r"\s+")
+
+
+def _normalize(s: str) -> str:
+    s = s.strip().lower()
+    s = _RE_NON_ALNUM.sub(" ", s)
+    return _RE_SPACES.sub(" ", s).strip()
+
+
+async def _fetch_schedule(session, date_str: str) -> list[dict[str, Any]]:
+    """Return (and cache) the TVMaze Germany schedule for *date_str* (YYYY-MM-DD)."""
+    if date_str in _schedule_cache:
+        return _schedule_cache[date_str]
+
+    params = {"country": "DE", "date": date_str}
+    try:
+        async with session.get(TVMAZE_SCHEDULE_URL, params=params, timeout=15) as resp:
+            resp.raise_for_status()
+            payload = await resp.json(**_JSON_KW)
+    except Exception as err:
+        _LOGGER.debug("TVMaze schedule fetch failed (date=%s): %s", date_str, err)
+        return []
+
+    if not isinstance(payload, list):
+        return []
+
+    _schedule_cache[date_str] = payload
+
+    # Evict old entries – keep only today and yesterday.
+    for old_key in [k for k in _schedule_cache if k < date_str]:
+        del _schedule_cache[old_key]
+
+    _LOGGER.debug("TVMaze schedule: cached %d entries for %s", len(payload), date_str)
+    return payload
+
+
+def _network_name(episode: dict[str, Any]) -> str:
+    """Extract the network / web-channel name from a TVMaze schedule entry."""
+    show = episode.get("show") or {}
+    network = show.get("network") or {}
+    web_channel = show.get("webChannel") or {}
+    return str(network.get("name") or web_channel.get("name") or "")
+
+
+def _channel_matches(episode: dict[str, Any], channel_tokens: list[str]) -> bool:
+    """Return True if every channel token appears in the episode's network name."""
+    net = _normalize(_network_name(episode))
+    if not net:
+        return False
+    return all(tok in net for tok in channel_tokens if len(tok) >= 2)
+
+
+def _is_airing_now(episode: dict[str, Any], now: datetime) -> bool:
+    """Return True if the episode is currently on air."""
+    airstamp = episode.get("airstamp")
+    runtime = episode.get("runtime") or 30
+    if not airstamp:
+        return False
+    try:
+        start = datetime.fromisoformat(airstamp)
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return False
+    return start <= now <= start + timedelta(minutes=runtime)
+
+
+def _image_url(episode: dict[str, Any]) -> str | None:
+    """Return the best available image URL for an episode (prefer episode over show)."""
+    for source in (episode.get("image"), (episode.get("show") or {}).get("image")):
+        if isinstance(source, dict):
+            url = source.get("original") or source.get("medium")
+            if isinstance(url, str) and url:
+                return url
+    return None
+
+
+async def async_get_current_program(
+    session,
+    channel_name: str,
+) -> dict[str, Any] | None:
+    """Return metadata for the program currently airing on *channel_name*.
+
+    Uses the TVMaze Germany schedule (free, no API key).  The channel name is
+    matched against TVMaze network names via token overlap, so fuzzy variants
+    like 'WDR', 'WDR HD', 'wdr fernsehen' all resolve correctly.
+
+    Returns a dict with:
+        title     – episode/programme title (may be empty string)
+        show_name – series/show name
+        image_url – URL of the best available image, or None
+    or None if nothing could be found.
+    """
+    channel_tokens = _normalize(channel_name).split()
+    if not channel_tokens:
+        return None
+
+    now = datetime.now(tz=timezone.utc)
+    date_str = now.strftime("%Y-%m-%d")
+
+    # Late-night shows may have started yesterday.
+    for fetch_date in (date_str, (now - timedelta(days=1)).strftime("%Y-%m-%d")):
+        schedule = await _fetch_schedule(session, fetch_date)
+        for episode in schedule:
+            if not isinstance(episode, dict):
+                continue
+            if not _channel_matches(episode, channel_tokens):
+                continue
+            if not _is_airing_now(episode, now):
+                continue
+
+            show = episode.get("show") or {}
+            result = {
+                "title": str(episode.get("name") or ""),
+                "show_name": str(show.get("name") or ""),
+                "image_url": _image_url(episode),
+            }
+            _LOGGER.debug(
+                "EPG match: channel=%r → show=%r episode=%r",
+                channel_name, result["show_name"], result["title"],
+            )
+            return result
+
+    _LOGGER.debug("EPG: no current program found for channel=%r", channel_name)
+    return None

--- a/custom_components/media_art_wrapper/tv.py
+++ b/custom_components/media_art_wrapper/tv.py
@@ -4,6 +4,7 @@ import logging
 import re
 from typing import Any
 
+from .epg import async_get_current_program
 from .models import ResolvedCover, TrackQuery
 
 _LOGGER = logging.getLogger(__name__)
@@ -363,10 +364,15 @@ async def async_tv_resolve(*, session, query: TrackQuery) -> ResolvedCover | Non
     """Resolve artwork for TV content.
 
     Search order:
+      0. EPG (TVMaze DE schedule) – if the title looks like a channel name,
+         look up what's currently airing and use that program's artwork.
+         If the EPG returns a show title but no image, that title is fed into
+         the artwork searches below instead of the raw channel name.
       1. iTunes TV (tvShow + movie entity) – matches show/movie names.
-      2. TVMaze – TV shows, freely accessible without API key.
-      3. Wikipedia thumbnail – used as a last resort for channel logos
-         (e.g. "WDR HD Wuppertal" → strip suffix → look up "WDR").
+      2. TVMaze show search – TV shows, freely accessible without API key.
+      3. Channel logo lookup:
+         3a. ÖRR HD list page (curated, Europe-wide public broadcasters).
+         3b. Generic Wikipedia article lookup as final fallback.
     """
     title = (query.title or "").strip()
     artist = (query.artist or "").strip()
@@ -378,22 +384,50 @@ async def async_tv_resolve(*, session, query: TrackQuery) -> ResolvedCover | Non
     artwork_url: str | None = None
     provider_name: str | None = None
 
-    # 1. iTunes TV ----------------------------------------------------------
-    artwork_url = await _itunes_tv(session, search_term, match_name=title or artist)
-    if artwork_url:
-        # Scale up the iTunes thumbnail to the requested size.
-        target = max(100, int(max(query.artwork_width, query.artwork_height)))
-        artwork_url = re.sub(
-            r"/(\d{2,4})x(\d{2,4})bb\.(jpg|png)$",
-            f"/{target}x{target}bb.jpg",
-            artwork_url,
-            flags=re.IGNORECASE,
-        )
-        provider_name = "tv_itunes"
+    # The "effective" search term used for iTunes/TVMaze show searches.
+    # May be replaced with the EPG program title when available.
+    effective_search = search_term
 
-    # 2. TVMaze -------------------------------------------------------------
+    # 0. EPG lookup ---------------------------------------------------------
+    # Only useful when the title contains a broadcast-technical suffix (HD/SD)
+    # or when artist is absent – both are strong indicators of a channel name.
+    stripped_title = _strip_channel_suffix(title)
+    is_channel_name = stripped_title != title or not artist
+    if is_channel_name and title:
+        epg = await async_get_current_program(session, stripped_title or title)
+        if epg:
+            if epg.get("image_url"):
+                # Use the programme image directly.
+                artwork_url = epg["image_url"]
+                provider_name = "tv_epg"
+                _LOGGER.debug(
+                    "EPG hit: channel=%r → programme=%r image=%r",
+                    title, epg.get("show_name") or epg.get("title"), artwork_url,
+                )
+            elif epg.get("show_name") or epg.get("title"):
+                # No image but we have a title – use it for artwork searches.
+                effective_search = epg.get("show_name") or epg.get("title") or search_term
+                _LOGGER.debug(
+                    "EPG title redirect: channel=%r → search=%r",
+                    title, effective_search,
+                )
+
+    # 1. iTunes TV ----------------------------------------------------------
     if not artwork_url:
-        artwork_url = await _tvmaze(session, title or search_term)
+        artwork_url = await _itunes_tv(session, effective_search, match_name=effective_search)
+        if artwork_url:
+            target = max(100, int(max(query.artwork_width, query.artwork_height)))
+            artwork_url = re.sub(
+                r"/(\d{2,4})x(\d{2,4})bb\.(jpg|png)$",
+                f"/{target}x{target}bb.jpg",
+                artwork_url,
+                flags=re.IGNORECASE,
+            )
+            provider_name = "tv_itunes"
+
+    # 2. TVMaze show search -------------------------------------------------
+    if not artwork_url:
+        artwork_url = await _tvmaze(session, effective_search)
         if artwork_url:
             provider_name = "tv_tvmaze"
 


### PR DESCRIPTION
New module epg.py provides async_get_current_program() which:
- Queries the TVMaze Germany schedule (free, no API key required)
- Matches channel name tokens against TVMaze network names (e.g. 'WDR', 'WDR HD', 'wdr fernsehen' all resolve to WDR)
- Handles late-night shows by also checking yesterday's schedule
- Caches the daily schedule to avoid repeated API calls; evicts entries older than yesterday automatically

Integration in tv.py (new step 0):
- Triggered when title looks like a channel name (contains HD/SD suffix or artist field is absent)
- If EPG returns an image  → use it directly (provider: tv_epg)
- If EPG returns a title but no image → redirect iTunes TV / TVMaze show searches to the programme title instead of the raw channel name (e.g. search "Tatort" instead of "WDR")
- Falls back to channel logo lookup if EPG finds nothing

Result: watching "WDR HD Wuppertal" now shows artwork for the currently airing programme rather than just the WDR logo.

https://claude.ai/code/session_01QiZrUk8uyr8CQcdUiTHeRS