### PR TITLE
feat: v3.0.0 — category-aware providers, 3-step config flow, smart fa…

### DIFF
--- a/custom_components/media_art_wrapper/__init__.py
+++ b/custom_components/media_art_wrapper/__init__.py
@@ -15,26 +15,27 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    CATEGORY_AUTO,
     CONF_ARTWORK_HEIGHT,
     CONF_ARTWORK_SIZE,
     CONF_ARTWORK_WIDTH,
-    CONF_PROVIDERS,
+    CONF_CATEGORY,
+    CONF_FALLBACK_MODE,
     CONF_SOURCE_ENTITY_ID,
     DEFAULT_ARTWORK_HEIGHT,
     DEFAULT_ARTWORK_SIZE,
     DEFAULT_ARTWORK_WIDTH,
-    DEFAULT_PROVIDERS,
     DOMAIN,
+    FALLBACK_PLACEHOLDER,
     PLATFORMS,
+    RATIO_1_1,
 )
-from .cover_resolver import async_resolve_cover
-from .models import TrackQuery
+from .providers import get_providers, resolve_cover
+from .providers.query_builder import build_query
 
 _LOGGER = logging.getLogger(__name__)
 
-# Detects station-ident metadata: no artist AND title contains " - " which
-# radio stations use for "STATIONNAME - SLOGAN" (e.g. "WDR 2 - Für den Westen").
-# Real track titles without an artist field rarely contain " - ".
+# Station-ident heuristic: no artist AND title contains " - " (e.g. "WDR 2 - Für den Westen")
 _RE_STATION_IDENT = re.compile(r".+\s+-\s+.+")
 
 _RE_CLEAN = re.compile(
@@ -64,9 +65,10 @@ class CoverData:
     content_type: str
     image: bytes | None
     last_updated: datetime | None
+    category: str = CATEGORY_AUTO
 
 
-def _raw_text(value: str | None) -> str | None:
+def _raw_text(value: Any) -> str | None:
     """Normalize whitespace only – keeps remix/edit/mix annotations intact."""
     if not isinstance(value, str):
         return None
@@ -76,7 +78,7 @@ def _raw_text(value: str | None) -> str | None:
     return normalized or None
 
 
-def _clean_text(value: str | None) -> str | None:
+def _clean_text(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
     cleaned = re.sub(r"\s{2,}", " ", _RE_CLEAN.sub("", value)).strip()
@@ -104,7 +106,7 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         self.entry = entry
         self.source_entity_id: str = entry.data[CONF_SOURCE_ENTITY_ID]
-        self.providers: list[str] = []
+        self.category: str = CATEGORY_AUTO
         self.artwork_size: int = DEFAULT_ARTWORK_SIZE
         self.artwork_width: int = DEFAULT_ARTWORK_WIDTH
         self.artwork_height: int = DEFAULT_ARTWORK_HEIGHT
@@ -115,6 +117,7 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
 
         self._update_from_entry(entry)
 
+        self._state_attrs: dict[str, Any] = {}
         self._artist: str | None = None
         self._title: str | None = None
         self._raw_title: str | None = None
@@ -132,16 +135,18 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
         )
 
     def _update_from_entry(self, entry: ConfigEntry) -> None:
-        providers = entry.options.get(CONF_PROVIDERS, entry.data.get(CONF_PROVIDERS, DEFAULT_PROVIDERS))
-        self.providers = list(providers) if isinstance(providers, list) else list(DEFAULT_PROVIDERS)
+        opts = entry.options
+        data = entry.data
 
-        artwork_width = entry.options.get(
+        self.category = str(opts.get(CONF_CATEGORY, data.get(CONF_CATEGORY, CATEGORY_AUTO)))
+
+        artwork_width = opts.get(
             CONF_ARTWORK_WIDTH,
-            entry.data.get(CONF_ARTWORK_WIDTH, entry.data.get(CONF_ARTWORK_SIZE, DEFAULT_ARTWORK_WIDTH)),
+            data.get(CONF_ARTWORK_WIDTH, data.get(CONF_ARTWORK_SIZE, DEFAULT_ARTWORK_WIDTH)),
         )
-        artwork_height = entry.options.get(
+        artwork_height = opts.get(
             CONF_ARTWORK_HEIGHT,
-            entry.data.get(CONF_ARTWORK_HEIGHT, entry.data.get(CONF_ARTWORK_SIZE, DEFAULT_ARTWORK_HEIGHT)),
+            data.get(CONF_ARTWORK_HEIGHT, data.get(CONF_ARTWORK_SIZE, DEFAULT_ARTWORK_HEIGHT)),
         )
 
         self.artwork_width = int(artwork_width)
@@ -186,25 +191,22 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
         if state is None or state.state in {"unavailable", "unknown"}:
             return False
 
-        attrs = state.attributes or {}
+        attrs = dict(state.attributes or {})
         raw_title = _raw_text(attrs.get("media_title"))
         artist = _clean_text(attrs.get("media_artist"))
         title = _clean_text(attrs.get("media_title"))
         album = _clean_text(attrs.get("media_album_name"))
 
-        # Heuristic: no artist AND title looks like "STATIONNAME - SLOGAN"
-        # (e.g. "WDR 2 - Für den Westen"). Treat as no usable track info so
-        # the last successful cover is kept instead of triggering a new search.
+        # Heuristic: no artist AND title looks like "STATIONNAME - SLOGAN".
         if not artist and title and _RE_STATION_IDENT.match(title):
             _LOGGER.debug("Skipping station-ident title %r (no artist)", title)
             return False
 
-        # Use raw title in the key so "Song (Remix)" and "Song" are treated as
-        # distinct tracks and each triggers its own cover fetch.
         new_key = _build_track_key(artist, raw_title, album)
         if new_key == self._track_key:
             return False
 
+        self._state_attrs = attrs
         self._artist = artist
         self._title = title
         self._raw_title = raw_title
@@ -237,6 +239,7 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
             content_type="image/jpeg",
             image=None,
             last_updated=None,
+            category=self.category,
         )
 
     async def _async_update_data(self) -> CoverData:
@@ -251,22 +254,14 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
                 return self._fallback_data(track_key=None, artist=artist, title=title, album=album)
 
             try:
-                raw_title = self._raw_title
-                query = TrackQuery(
-                    artist=artist,
-                    title=title,
-                    album=album,
+                query = build_query(
+                    state_attrs=self._state_attrs,
+                    category=self.category,
                     artwork_width=self.artwork_width,
                     artwork_height=self.artwork_height,
-                    # Pass raw title so the resolver can try it first (e.g. "Song (Remix)")
-                    # before falling back to the cleaned title ("Song").
-                    original_title=raw_title if raw_title != title else None,
                 )
-                resolved = await async_resolve_cover(
-                    session=self._session,
-                    query=query,
-                    providers=self.providers,
-                )
+                providers = get_providers(self.category, self.entry.options)
+                resolved = await resolve_cover(self._session, query, providers)
             except Exception as err:  # noqa: BLE001
                 self._last_error = str(err)
                 _LOGGER.warning(
@@ -288,11 +283,12 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
                 artist=artist,
                 title=title,
                 album=album,
-                provider=resolved.provider,
-                artwork_url=resolved.artwork_url,
+                provider=resolved.provider_name,
+                artwork_url=resolved.image_url,
                 content_type=resolved.content_type,
                 image=resolved.image,
                 last_updated=dt_util.utcnow(),
+                category=self.category,
             )
             self._last_cover = data
             return data
@@ -301,13 +297,12 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
 async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate config entries to the current schema version.
 
-    Each block handles exactly one version step so the chain is fully additive:
-    future migrations just append another ``if current_version < N`` block.
-
     Version history
     ---------------
     1  – initial release; artwork stored as a single ``artwork_size`` value.
     2  – ``artwork_size`` replaced by separate ``artwork_width`` / ``artwork_height``.
+    3  – Added category, display_name, ratio, fallback_mode, auto_priority;
+         providers/ subpackage replaces old flat provider list.
     """
     current_version: int = entry.version
     _LOGGER.debug("Migrating config entry %s from version %s", entry.entry_id, current_version)
@@ -316,9 +311,6 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     new_options = dict(entry.options)
 
     if current_version < 2:
-        # Split the legacy unified ``artwork_size`` field into the two separate
-        # dimension fields.  Applies to both ``data`` and ``options`` so that
-        # entries whose options were written by the old flow are also cleaned up.
         for store in (new_data, new_options):
             if CONF_ARTWORK_SIZE in store:
                 size = int(store.pop(CONF_ARTWORK_SIZE))
@@ -327,6 +319,28 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         current_version = 2
         _LOGGER.info(
             "Migrated config entry %s: v1 → v2 (artwork_size → artwork_width/artwork_height)",
+            entry.entry_id,
+        )
+
+    if current_version < 3:
+        # Add new v3 fields with sensible defaults
+        new_options.setdefault(CONF_CATEGORY, CATEGORY_AUTO)
+        new_options.setdefault(CONF_FALLBACK_MODE, FALLBACK_PLACEHOLDER)
+
+        # Derive display_name from source entity_id if not present
+        src = new_data.get(CONF_SOURCE_ENTITY_ID, "")
+        derived_name = src.split(".", 1)[-1].replace("_", " ").title() if src else ""
+        new_options.setdefault("display_name", derived_name)
+        new_options.setdefault("ratio", RATIO_1_1)
+        new_options.setdefault("auto_priority", True)
+
+        # Remove legacy flat provider list (providers are now derived from category)
+        new_options.pop("providers", None)
+        new_data.pop("providers", None)
+
+        current_version = 3
+        _LOGGER.info(
+            "Migrated config entry %s: v2 → v3 (added category/display_name/ratio/fallback_mode)",
             entry.entry_id,
         )
 

--- a/custom_components/media_art_wrapper/config_flow.py
+++ b/custom_components/media_art_wrapper/config_flow.py
@@ -1,3 +1,4 @@
+"""Config flow — 3-step setup for Media Art Wrapper v3."""
 from __future__ import annotations
 
 from typing import Any
@@ -5,125 +6,100 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import selector
 
 from .const import (
+    CATEGORIES,
+    CATEGORY_AUTO,
+    CATEGORY_GAMING,
+    CATEGORY_MUSIC,
+    CATEGORY_STREAMING,
+    CATEGORY_TV,
     COMBINED_NUM_SOURCE_SLOTS,
+    CONF_AUTO_PRIORITY,
     CONF_ARTWORK_HEIGHT,
-    CONF_ARTWORK_SIZE,
     CONF_ARTWORK_WIDTH,
+    CONF_CATEGORY,
     CONF_COMBINED_AUDIO_SOURCES,
     CONF_COMBINED_NAME,
     CONF_COMBINED_SOURCES,
     CONF_CREATE_COMBINED,
-    CONF_PROVIDERS,
+    CONF_DISPLAY_NAME,
+    CONF_FALLBACK_CUSTOM_URL,
+    CONF_FALLBACK_MODE,
+    CONF_FANART_API_KEY,
+    CONF_IGDB_CLIENT_ID,
+    CONF_IGDB_CLIENT_SECRET,
+    CONF_RATIO,
     CONF_SOURCE_ENTITY_ID,
+    CONF_STEAMGRIDDB_API_KEY,
+    CONF_TMDB_API_KEY,
+    CONF_XMLTV_URL,
     DEFAULT_ARTWORK_HEIGHT,
-    DEFAULT_ARTWORK_SIZE,
     DEFAULT_ARTWORK_WIDTH,
-    DEFAULT_PROVIDERS,
     DOMAIN,
-    PROVIDER_BATTLENET,
-    PROVIDER_ITUNES,
-    PROVIDER_MUSICBRAINZ,
-    PROVIDER_STEAM,
-    PROVIDER_TV,
+    FALLBACK_CUSTOM_URL_MODE,
+    FALLBACK_PLACEHOLDER,
+    FALLBACK_SERVICE_LOGO,
+    RATIO_1_1,
+    RATIO_4_3,
+    RATIO_16_9,
+    RATIO_CUSTOM,
+    RATIO_DIMENSIONS,
 )
 
 # ---------------------------------------------------------------------------
-# Provider priority slots
+# UI helpers
 # ---------------------------------------------------------------------------
 
-# Internal form-field names for the priority slots (UI only, not persisted)
-_SLOT_KEYS = ["provider_1", "provider_2", "provider_3", "provider_4", "provider_5"]
-
-# Sentinel value for an empty / disabled slot
-_NONE = ""
-
-_PROVIDER_OPTIONS_WITH_NONE = [
-    {"value": _NONE, "label": "—"},
-    {"value": PROVIDER_ITUNES, "label": "iTunes (Apple Search API)"},
-    {"value": PROVIDER_MUSICBRAINZ, "label": "MusicBrainz + Cover Art Archive"},
-    {"value": PROVIDER_TV, "label": "TV (iTunes TV + TVMaze + Wikipedia-Senderlogos)"},
-    {"value": PROVIDER_BATTLENET, "label": "Battle.net (Overwatch, WoW, Hearthstone, …)"},
-    {"value": PROVIDER_STEAM, "label": "Steam (alle Steam-Spiele, z. B. Civilization VII)"},
+_CATEGORY_OPTIONS = [
+    {"value": CATEGORY_MUSIC,     "label": "Music"},
+    {"value": CATEGORY_STREAMING, "label": "Streaming (films & series)"},
+    {"value": CATEGORY_GAMING,    "label": "Gaming"},
+    {"value": CATEGORY_TV,        "label": "TV / Live TV"},
+    {"value": CATEGORY_AUTO,      "label": "Auto (try all providers)"},
 ]
 
-_SLOT_SELECTOR = selector.SelectSelector(
-    selector.SelectSelectorConfig(
-        options=_PROVIDER_OPTIONS_WITH_NONE,
-        multiple=False,
-        mode=selector.SelectSelectorMode.DROPDOWN,
-    )
-)
-
-# ---------------------------------------------------------------------------
-# Artwork size presets
-# ---------------------------------------------------------------------------
-
-# UI-only field key for the preset selector (not persisted)
-_CONF_ARTWORK_PRESET = "artwork_preset"
-_PRESET_CUSTOM = "custom"
-
-# Ordered (width, height) for each preset key
-_ARTWORK_PRESETS: dict[str, tuple[int, int]] = {
-    "300x300": (300, 300),
-    "600x600": (600, 600),
-    "800x800": (800, 800),
-    "1000x1000": (1000, 1000),
-    "600x900": (600, 900),
-    "1200x1800": (1200, 1800),
-}
-
-_PRESET_OPTIONS = [
-    {"value": "300x300",    "label": "300 × 300 px"},
-    {"value": "600x600",    "label": "600 × 600 px (Standard)"},
-    {"value": "800x800",    "label": "800 × 800 px"},
-    {"value": "1000x1000",  "label": "1000 × 1000 px"},
-    {"value": "600x900",    "label": "600 × 900 px (Hochformat, z. B. Steam)"},
-    {"value": "1200x1800",  "label": "1200 × 1800 px (Hochformat HD, Steam 2×)"},
-    {"value": _PRESET_CUSTOM, "label": "Benutzerdefiniert …"},
+_RATIO_OPTIONS = [
+    {"value": RATIO_1_1,     "label": "1:1  — 600 × 600 px (music / gaming)"},
+    {"value": RATIO_4_3,     "label": "4:3  — 800 × 600 px"},
+    {"value": RATIO_16_9,    "label": "16:9 — 960 × 540 px (landscape TV)"},
+    {"value": RATIO_CUSTOM,  "label": "Custom …"},
 ]
 
-_PRESET_SELECTOR = selector.SelectSelector(
-    selector.SelectSelectorConfig(
-        options=_PRESET_OPTIONS,
-        multiple=False,
-        mode=selector.SelectSelectorMode.DROPDOWN,
-    )
-)
+_FALLBACK_OPTIONS = [
+    {"value": FALLBACK_PLACEHOLDER,    "label": "Placeholder icon"},
+    {"value": FALLBACK_SERVICE_LOGO,   "label": "Service logo (auto-detected)"},
+    {"value": FALLBACK_CUSTOM_URL_MODE, "label": "Custom URL …"},
+]
 
-
-def _detect_preset(width: int, height: int) -> str:
-    """Return the preset key matching (width, height), or _PRESET_CUSTOM."""
-    for key, dims in _ARTWORK_PRESETS.items():
-        if dims == (width, height):
-            return key
-    return _PRESET_CUSTOM
-
-
-# ---------------------------------------------------------------------------
-# Combined Player helpers
-# ---------------------------------------------------------------------------
-
-# Internal form-field names for the 8 combined source priority slots (UI only)
 _COMBINED_SLOT_KEYS = [f"combined_source_{i}" for i in range(1, COMBINED_NUM_SOURCE_SLOTS + 1)]
 
-_COMBINED_ENTITY_SELECTOR = selector.EntitySelector(
+_ENTITY_SEL = selector.EntitySelector(
     selector.EntitySelectorConfig(domain="media_player", multiple=False)
 )
-
-_COMBINED_AUDIO_SELECTOR = selector.EntitySelector(
+_MULTI_ENTITY_SEL = selector.EntitySelector(
     selector.EntitySelectorConfig(domain="media_player", multiple=True)
 )
 
 
-def _combined_slots_to_sources(form_data: dict[str, Any]) -> list[str]:
-    """Convert numbered slot form values to an ordered sources list.
+def _ratio_to_dims(ratio: str, width: int, height: int) -> tuple[int, int]:
+    """Return (width, height) from a ratio preset or custom values."""
+    if ratio in RATIO_DIMENSIONS:
+        return RATIO_DIMENSIONS[ratio]
+    return (max(1, width), max(1, height))
 
-    Duplicates and absent/empty slots are silently dropped.
-    """
+
+def _dims_to_ratio(width: int, height: int) -> str:
+    """Return the ratio key that matches (width, height), or RATIO_CUSTOM."""
+    for key, dims in RATIO_DIMENSIONS.items():
+        if dims == (width, height):
+            return key
+    return RATIO_CUSTOM
+
+
+def _combined_slots_to_sources(form_data: dict[str, Any]) -> list[str]:
     seen: set[str] = set()
     result: list[str] = []
     for key in _COMBINED_SLOT_KEYS:
@@ -135,233 +111,340 @@ def _combined_slots_to_sources(form_data: dict[str, Any]) -> list[str]:
 
 
 def _combined_sources_to_slots(sources: list[str]) -> dict[str, str]:
-    """Return a mapping of slot-key → entity_id for filled slots only."""
     return {
         _COMBINED_SLOT_KEYS[i]: sources[i]
         for i in range(min(len(sources), COMBINED_NUM_SOURCE_SLOTS))
     }
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-def _providers_to_slots(providers: list[str]) -> dict[str, str]:
-    """Convert an ordered providers list to the numbered slot form values."""
-    slots: dict[str, str] = {}
-    for i, key in enumerate(_SLOT_KEYS):
-        slots[key] = providers[i] if i < len(providers) else _NONE
-    return slots
-
-
-def _slots_to_providers(form_data: dict[str, Any]) -> list[str]:
-    """Convert numbered slot form values back to an ordered providers list.
-
-    Duplicates and empty slots are silently dropped.
-    """
-    seen: set[str] = set()
-    result: list[str] = []
-    for key in _SLOT_KEYS:
-        val = str(form_data.get(key, _NONE)).strip()
-        if val and val not in seen:
-            seen.add(val)
-            result.append(val)
-    return result or list(DEFAULT_PROVIDERS)
-
-
-def _resolve_dimensions(form_data: dict[str, Any]) -> tuple[int, int]:
-    """Return (width, height) from form data, honouring the preset selector."""
-    preset = str(form_data.get(_CONF_ARTWORK_PRESET, _PRESET_CUSTOM))
-    if preset in _ARTWORK_PRESETS:
-        return _ARTWORK_PRESETS[preset]
-    width = int(form_data.get(CONF_ARTWORK_WIDTH, DEFAULT_ARTWORK_WIDTH))
-    height = int(form_data.get(CONF_ARTWORK_HEIGHT, DEFAULT_ARTWORK_HEIGHT))
-    return width, height
-
-
-def _slot_schema(
-    source_entity_id: str | None,
-    slots: dict[str, str],
-    artwork_width: int,
-    artwork_height: int,
-    *,
-    include_source: bool,
-    create_combined: bool = False,
-    combined_name: str = "",
-    combined_sources: list[str] | None = None,
-    combined_audio_sources: list[str] | None = None,
-) -> vol.Schema:
-    fields: dict[Any, Any] = {}
-
-    if include_source:
-        fields[vol.Required(CONF_SOURCE_ENTITY_ID, default=source_entity_id)] = (
-            selector.EntitySelector(
-                selector.EntitySelectorConfig(domain="media_player", multiple=False)
-            )
-        )
-
-    for key in _SLOT_KEYS:
-        fields[vol.Optional(key, default=slots.get(key, _NONE))] = _SLOT_SELECTOR
-
-    fields[vol.Optional(_CONF_ARTWORK_PRESET, default=_detect_preset(artwork_width, artwork_height))] = (
-        _PRESET_SELECTOR
-    )
-    fields[vol.Optional(CONF_ARTWORK_WIDTH, default=artwork_width)] = vol.All(
-        vol.Coerce(int), vol.Range(min=1)
-    )
-    fields[vol.Optional(CONF_ARTWORK_HEIGHT, default=artwork_height)] = vol.All(
-        vol.Coerce(int), vol.Range(min=1)
-    )
-
-    # ---- Combined Player section ----
-    fields[vol.Optional(CONF_CREATE_COMBINED, default=create_combined)] = (
-        selector.BooleanSelector()
-    )
-    fields[vol.Optional(CONF_COMBINED_NAME, default=combined_name)] = (
-        selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT))
-    )
-
-    # 8 priority slots for combined sources
-    slot_defaults = _combined_sources_to_slots(combined_sources or [])
-    for key in _COMBINED_SLOT_KEYS:
-        existing = slot_defaults.get(key)
-        if existing:
-            fields[vol.Optional(key, default=existing)] = _COMBINED_ENTITY_SELECTOR
-        else:
-            fields[vol.Optional(key)] = _COMBINED_ENTITY_SELECTOR
-
-    # Multi-select audio sources
-    fields[vol.Optional(CONF_COMBINED_AUDIO_SOURCES, default=combined_audio_sources or [])] = (
-        _COMBINED_AUDIO_SELECTOR
-    )
-
-    return vol.Schema(fields)
-
-
 async def _friendly_name(hass: HomeAssistant, entity_id: str) -> str:
     state = hass.states.get(entity_id)
     if state and "friendly_name" in state.attributes:
         return str(state.attributes["friendly_name"])
-    return entity_id
+    return entity_id.split(".", 1)[-1].replace("_", " ").title()
 
 
 # ---------------------------------------------------------------------------
-# Config flow
+# Schema builders
+# ---------------------------------------------------------------------------
+
+def _step1_schema(
+    source_entity_id: str | None = None,
+    display_name: str = "",
+    category: str = CATEGORY_AUTO,
+    *,
+    include_source: bool = True,
+) -> vol.Schema:
+    fields: dict[Any, Any] = {}
+    if include_source:
+        kw: dict[str, Any] = {"default": source_entity_id} if source_entity_id else {}
+        fields[vol.Required(CONF_SOURCE_ENTITY_ID, **kw)] = _ENTITY_SEL
+    fields[vol.Optional(CONF_DISPLAY_NAME, default=display_name)] = selector.TextSelector(
+        selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+    )
+    fields[vol.Required(CONF_CATEGORY, default=category)] = selector.SelectSelector(
+        selector.SelectSelectorConfig(
+            options=_CATEGORY_OPTIONS,
+            multiple=False,
+            mode=selector.SelectSelectorMode.DROPDOWN,
+        )
+    )
+    return vol.Schema(fields)
+
+
+def _step2_schema(
+    category: str,
+    opts: dict[str, Any],
+) -> vol.Schema:
+    """Build the artwork + API-keys step schema for the given category."""
+    ratio = opts.get(CONF_RATIO, RATIO_1_1)
+    width = int(opts.get(CONF_ARTWORK_WIDTH, DEFAULT_ARTWORK_WIDTH))
+    height = int(opts.get(CONF_ARTWORK_HEIGHT, DEFAULT_ARTWORK_HEIGHT))
+    fallback_mode = opts.get(CONF_FALLBACK_MODE, FALLBACK_PLACEHOLDER)
+    fallback_url = opts.get(CONF_FALLBACK_CUSTOM_URL, "")
+
+    fields: dict[Any, Any] = {
+        vol.Required(CONF_RATIO, default=ratio): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=_RATIO_OPTIONS,
+                multiple=False,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(CONF_ARTWORK_WIDTH, default=width): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        vol.Optional(CONF_ARTWORK_HEIGHT, default=height): vol.All(vol.Coerce(int), vol.Range(min=1)),
+        vol.Required(CONF_FALLBACK_MODE, default=fallback_mode): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=_FALLBACK_OPTIONS,
+                multiple=False,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        ),
+        vol.Optional(CONF_FALLBACK_CUSTOM_URL, default=fallback_url): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.URL)
+        ),
+    }
+
+    # Category-specific API key fields
+    if category in (CATEGORY_STREAMING, CATEGORY_AUTO):
+        fields[vol.Optional(CONF_TMDB_API_KEY, default=opts.get(CONF_TMDB_API_KEY, ""))] = (
+            selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD))
+        )
+
+    if category in (CATEGORY_GAMING, CATEGORY_AUTO):
+        fields[vol.Optional(CONF_IGDB_CLIENT_ID, default=opts.get(CONF_IGDB_CLIENT_ID, ""))] = (
+            selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT))
+        )
+        fields[vol.Optional(CONF_IGDB_CLIENT_SECRET, default=opts.get(CONF_IGDB_CLIENT_SECRET, ""))] = (
+            selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD))
+        )
+        fields[vol.Optional(CONF_STEAMGRIDDB_API_KEY, default=opts.get(CONF_STEAMGRIDDB_API_KEY, ""))] = (
+            selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD))
+        )
+
+    if category in (CATEGORY_TV, CATEGORY_AUTO):
+        fields[vol.Optional(CONF_FANART_API_KEY, default=opts.get(CONF_FANART_API_KEY, ""))] = (
+            selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD))
+        )
+        fields[vol.Optional(CONF_XMLTV_URL, default=opts.get(CONF_XMLTV_URL, ""))] = (
+            selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.URL))
+        )
+
+    return vol.Schema(fields)
+
+
+def _step3_schema(
+    opts: dict[str, Any],
+    category: str,
+) -> vol.Schema:
+    create_combined = bool(opts.get(CONF_CREATE_COMBINED, False))
+    combined_name = str(opts.get(CONF_COMBINED_NAME, "")).strip()
+    combined_sources: list[str] = list(opts.get(CONF_COMBINED_SOURCES, []))
+    combined_audio: list[str] = list(opts.get(CONF_COMBINED_AUDIO_SOURCES, []))
+    auto_priority = bool(opts.get(CONF_AUTO_PRIORITY, True))
+
+    fields: dict[Any, Any] = {
+        vol.Optional(CONF_CREATE_COMBINED, default=create_combined): selector.BooleanSelector(),
+        vol.Optional(CONF_COMBINED_NAME, default=combined_name): selector.TextSelector(
+            selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+        ),
+        vol.Optional(CONF_AUTO_PRIORITY, default=auto_priority): selector.BooleanSelector(),
+    }
+
+    slot_defaults = _combined_sources_to_slots(combined_sources)
+    for key in _COMBINED_SLOT_KEYS:
+        existing = slot_defaults.get(key)
+        if existing:
+            fields[vol.Optional(key, default=existing)] = _ENTITY_SEL
+        else:
+            fields[vol.Optional(key)] = _ENTITY_SEL
+
+    fields[vol.Optional(CONF_COMBINED_AUDIO_SOURCES, default=combined_audio)] = _MULTI_ENTITY_SEL
+
+    return vol.Schema(fields)
+
+
+# ---------------------------------------------------------------------------
+# Config flow (3-step setup)
 # ---------------------------------------------------------------------------
 
 class MediaCoverArtConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    VERSION = 2
+    VERSION = 3
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._step1: dict[str, Any] = {}
+        self._step2: dict[str, Any] = {}
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
-        errors: dict[str, str] = {}
-
         if user_input is not None:
             source_entity_id = user_input[CONF_SOURCE_ENTITY_ID]
             await self.async_set_unique_id(source_entity_id)
             self._abort_if_unique_id_configured()
 
+            # Derive display_name from entity state if blank
+            display_name = str(user_input.get(CONF_DISPLAY_NAME, "")).strip()
+            if not display_name:
+                display_name = await _friendly_name(self.hass, source_entity_id)
+
+            self._step1 = {
+                CONF_SOURCE_ENTITY_ID: source_entity_id,
+                CONF_DISPLAY_NAME: display_name,
+                CONF_CATEGORY: user_input.get(CONF_CATEGORY, CATEGORY_AUTO),
+            }
+            return await self.async_step_artwork()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_step1_schema(include_source=True),
+        )
+
+    async def async_step_artwork(self, user_input: dict[str, Any] | None = None):
+        category = self._step1.get(CONF_CATEGORY, CATEGORY_AUTO)
+
+        if user_input is not None:
+            ratio = user_input.get(CONF_RATIO, RATIO_1_1)
+            width, height = _ratio_to_dims(
+                ratio,
+                int(user_input.get(CONF_ARTWORK_WIDTH, DEFAULT_ARTWORK_WIDTH)),
+                int(user_input.get(CONF_ARTWORK_HEIGHT, DEFAULT_ARTWORK_HEIGHT)),
+            )
+            self._step2 = {
+                CONF_RATIO: ratio,
+                CONF_ARTWORK_WIDTH: width,
+                CONF_ARTWORK_HEIGHT: height,
+                CONF_FALLBACK_MODE: user_input.get(CONF_FALLBACK_MODE, FALLBACK_PLACEHOLDER),
+                CONF_FALLBACK_CUSTOM_URL: user_input.get(CONF_FALLBACK_CUSTOM_URL, ""),
+                CONF_TMDB_API_KEY: user_input.get(CONF_TMDB_API_KEY, ""),
+                CONF_IGDB_CLIENT_ID: user_input.get(CONF_IGDB_CLIENT_ID, ""),
+                CONF_IGDB_CLIENT_SECRET: user_input.get(CONF_IGDB_CLIENT_SECRET, ""),
+                CONF_STEAMGRIDDB_API_KEY: user_input.get(CONF_STEAMGRIDDB_API_KEY, ""),
+                CONF_FANART_API_KEY: user_input.get(CONF_FANART_API_KEY, ""),
+                CONF_XMLTV_URL: user_input.get(CONF_XMLTV_URL, ""),
+            }
+            return await self.async_step_combined()
+
+        return self.async_show_form(
+            step_id="artwork",
+            data_schema=_step2_schema(category, {}),
+        )
+
+    async def async_step_combined(self, user_input: dict[str, Any] | None = None):
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
             create_combined = bool(user_input.get(CONF_CREATE_COMBINED, False))
             combined_name = str(user_input.get(CONF_COMBINED_NAME, "")).strip()
+
             if create_combined and not combined_name:
                 errors[CONF_COMBINED_NAME] = "combined_name_required"
 
             if not errors:
-                title = await _friendly_name(self.hass, source_entity_id)
-                artwork_width, artwork_height = _resolve_dimensions(user_input)
-
-                data = {
-                    CONF_SOURCE_ENTITY_ID: source_entity_id,
-                    CONF_PROVIDERS: _slots_to_providers(user_input),
-                    CONF_ARTWORK_WIDTH: artwork_width,
-                    CONF_ARTWORK_HEIGHT: artwork_height,
+                data = {CONF_SOURCE_ENTITY_ID: self._step1[CONF_SOURCE_ENTITY_ID]}
+                options = {
+                    **self._step1,
+                    **self._step2,
                     CONF_CREATE_COMBINED: create_combined,
                     CONF_COMBINED_NAME: combined_name,
                     CONF_COMBINED_SOURCES: _combined_slots_to_sources(user_input),
                     CONF_COMBINED_AUDIO_SOURCES: list(user_input.get(CONF_COMBINED_AUDIO_SOURCES) or []),
+                    CONF_AUTO_PRIORITY: bool(user_input.get(CONF_AUTO_PRIORITY, True)),
                 }
-                return self.async_create_entry(title=title, data=data)
+                # Remove source_entity_id from options (it lives only in data)
+                options.pop(CONF_SOURCE_ENTITY_ID, None)
 
-        schema = _slot_schema(
-            source_entity_id=None,
-            slots=_providers_to_slots(list(DEFAULT_PROVIDERS)),
-            artwork_width=DEFAULT_ARTWORK_WIDTH,
-            artwork_height=DEFAULT_ARTWORK_HEIGHT,
-            include_source=True,
+                title = self._step1.get(CONF_DISPLAY_NAME) or self._step1[CONF_SOURCE_ENTITY_ID]
+                return self.async_create_entry(title=title, data=data, options=options)
+
+        return self.async_show_form(
+            step_id="combined",
+            data_schema=_step3_schema({}, self._step1.get(CONF_CATEGORY, CATEGORY_AUTO)),
+            errors=errors,
         )
-        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
     @staticmethod
+    @callback
     def async_get_options_flow(config_entry: config_entries.ConfigEntry):
         return MediaCoverArtOptionsFlow(config_entry)
 
 
+# ---------------------------------------------------------------------------
+# Options flow (mirrors the 3 config steps, minus source_entity_id)
+# ---------------------------------------------------------------------------
+
 class MediaCoverArtOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        super().__init__(config_entry)
+        self._step1_opts: dict[str, Any] = {}
+        self._artwork_opts: dict[str, Any] = {}
+
+    def _current_opts(self) -> dict[str, Any]:
+        opts = dict(self.config_entry.options)
+        # Fall back to entry.data for legacy fields
+        for key in (CONF_CATEGORY, CONF_DISPLAY_NAME):
+            if key not in opts:
+                opts[key] = self.config_entry.data.get(key, "")
+        return opts
+
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        opts = self._current_opts()
+        category = opts.get(CONF_CATEGORY, CATEGORY_AUTO)
+        display_name = str(opts.get(CONF_DISPLAY_NAME, "")).strip()
+
+        if user_input is not None:
+            new_category = user_input.get(CONF_CATEGORY, CATEGORY_AUTO)
+            new_display_name = str(user_input.get(CONF_DISPLAY_NAME, "")).strip()
+            self._step1_opts = {
+                CONF_CATEGORY: new_category,
+                CONF_DISPLAY_NAME: new_display_name,
+            }
+            return await self.async_step_artwork()
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=_step1_schema(
+                display_name=display_name,
+                category=category,
+                include_source=False,
+            ),
+        )
+
+    async def async_step_artwork(self, user_input: dict[str, Any] | None = None):
+        opts = self._current_opts()
+        category = self._step1_opts.get(CONF_CATEGORY, opts.get(CONF_CATEGORY, CATEGORY_AUTO))
+
+        if user_input is not None:
+            ratio = user_input.get(CONF_RATIO, RATIO_1_1)
+            width, height = _ratio_to_dims(
+                ratio,
+                int(user_input.get(CONF_ARTWORK_WIDTH, DEFAULT_ARTWORK_WIDTH)),
+                int(user_input.get(CONF_ARTWORK_HEIGHT, DEFAULT_ARTWORK_HEIGHT)),
+            )
+            self._artwork_opts: dict[str, Any] = {
+                CONF_RATIO: ratio,
+                CONF_ARTWORK_WIDTH: width,
+                CONF_ARTWORK_HEIGHT: height,
+                CONF_FALLBACK_MODE: user_input.get(CONF_FALLBACK_MODE, FALLBACK_PLACEHOLDER),
+                CONF_FALLBACK_CUSTOM_URL: user_input.get(CONF_FALLBACK_CUSTOM_URL, ""),
+                CONF_TMDB_API_KEY: user_input.get(CONF_TMDB_API_KEY, ""),
+                CONF_IGDB_CLIENT_ID: user_input.get(CONF_IGDB_CLIENT_ID, ""),
+                CONF_IGDB_CLIENT_SECRET: user_input.get(CONF_IGDB_CLIENT_SECRET, ""),
+                CONF_STEAMGRIDDB_API_KEY: user_input.get(CONF_STEAMGRIDDB_API_KEY, ""),
+                CONF_FANART_API_KEY: user_input.get(CONF_FANART_API_KEY, ""),
+                CONF_XMLTV_URL: user_input.get(CONF_XMLTV_URL, ""),
+            }
+            return await self.async_step_combined()
+
+        return self.async_show_form(
+            step_id="artwork",
+            data_schema=_step2_schema(category, opts),
+        )
+
+    async def async_step_combined(self, user_input: dict[str, Any] | None = None):
+        opts = self._current_opts()
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            artwork_width, artwork_height = _resolve_dimensions(user_input)
             create_combined = bool(user_input.get(CONF_CREATE_COMBINED, False))
             combined_name = str(user_input.get(CONF_COMBINED_NAME, "")).strip()
+
             if create_combined and not combined_name:
                 errors[CONF_COMBINED_NAME] = "combined_name_required"
 
             if not errors:
-                data = {
-                    CONF_PROVIDERS: _slots_to_providers(user_input),
-                    CONF_ARTWORK_WIDTH: artwork_width,
-                    CONF_ARTWORK_HEIGHT: artwork_height,
+                new_options = {
+                    **self._step1_opts,
+                    **self._artwork_opts,
                     CONF_CREATE_COMBINED: create_combined,
                     CONF_COMBINED_NAME: combined_name,
                     CONF_COMBINED_SOURCES: _combined_slots_to_sources(user_input),
                     CONF_COMBINED_AUDIO_SOURCES: list(user_input.get(CONF_COMBINED_AUDIO_SOURCES) or []),
+                    CONF_AUTO_PRIORITY: bool(user_input.get(CONF_AUTO_PRIORITY, True)),
                 }
-                return self.async_create_entry(title="", data=data)
+                return self.async_create_entry(title="", data=new_options)
 
-        current_providers: list[str] = self.config_entry.options.get(
-            CONF_PROVIDERS,
-            self.config_entry.data.get(CONF_PROVIDERS, list(DEFAULT_PROVIDERS)),
+        return self.async_show_form(
+            step_id="combined",
+            data_schema=_step3_schema(opts, self._step1_opts.get(CONF_CATEGORY, opts.get(CONF_CATEGORY, CATEGORY_AUTO))),
+            errors=errors,
         )
-        artwork_width: int = self.config_entry.options.get(
-            CONF_ARTWORK_WIDTH,
-            self.config_entry.data.get(
-                CONF_ARTWORK_WIDTH,
-                self.config_entry.data.get(CONF_ARTWORK_SIZE, DEFAULT_ARTWORK_WIDTH),
-            ),
-        )
-        artwork_height: int = self.config_entry.options.get(
-            CONF_ARTWORK_HEIGHT,
-            self.config_entry.data.get(
-                CONF_ARTWORK_HEIGHT,
-                self.config_entry.data.get(CONF_ARTWORK_SIZE, DEFAULT_ARTWORK_HEIGHT),
-            ),
-        )
-        create_combined: bool = self.config_entry.options.get(
-            CONF_CREATE_COMBINED,
-            self.config_entry.data.get(CONF_CREATE_COMBINED, False),
-        )
-        combined_name: str = self.config_entry.options.get(
-            CONF_COMBINED_NAME,
-            self.config_entry.data.get(CONF_COMBINED_NAME, ""),
-        )
-        combined_sources: list[str] = self.config_entry.options.get(
-            CONF_COMBINED_SOURCES,
-            self.config_entry.data.get(CONF_COMBINED_SOURCES, []),
-        )
-        combined_audio_sources: list[str] = self.config_entry.options.get(
-            CONF_COMBINED_AUDIO_SOURCES,
-            self.config_entry.data.get(CONF_COMBINED_AUDIO_SOURCES, []),
-        )
-
-        schema = _slot_schema(
-            source_entity_id=None,
-            slots=_providers_to_slots(current_providers),
-            artwork_width=artwork_width,
-            artwork_height=artwork_height,
-            include_source=False,
-            create_combined=create_combined,
-            combined_name=combined_name,
-            combined_sources=combined_sources,
-            combined_audio_sources=combined_audio_sources,
-        )
-        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/custom_components/media_art_wrapper/const.py
+++ b/custom_components/media_art_wrapper/const.py
@@ -6,26 +6,139 @@ DOMAIN = "media_art_wrapper"
 
 PLATFORMS: list[Platform] = [Platform.IMAGE, Platform.CAMERA, Platform.MEDIA_PLAYER, Platform.SENSOR]
 
+# ---------------------------------------------------------------------------
+# Source / display
+# ---------------------------------------------------------------------------
 CONF_SOURCE_ENTITY_ID = "source_entity_id"
-CONF_PROVIDERS = "providers"
-CONF_ARTWORK_SIZE = "artwork_size"
+CONF_DISPLAY_NAME = "display_name"
+
+# ---------------------------------------------------------------------------
+# Category
+# ---------------------------------------------------------------------------
+CONF_CATEGORY = "category"
+
+CATEGORY_MUSIC = "music"
+CATEGORY_STREAMING = "streaming"
+CATEGORY_GAMING = "gaming"
+CATEGORY_TV = "tv"
+CATEGORY_AUTO = "auto"
+
+CATEGORIES = [CATEGORY_MUSIC, CATEGORY_STREAMING, CATEGORY_GAMING, CATEGORY_TV, CATEGORY_AUTO]
+
+# Category sort priority for Combined Player auto-priority
+# Lower number = higher priority (gaming beats streaming beats tv beats music)
+CATEGORY_SORT_PRIORITY: dict[str, int] = {
+    CATEGORY_GAMING: 1,
+    CATEGORY_STREAMING: 2,
+    CATEGORY_TV: 3,
+    CATEGORY_MUSIC: 4,
+    CATEGORY_AUTO: 5,
+}
+
+# ---------------------------------------------------------------------------
+# Artwork ratio & dimensions
+# ---------------------------------------------------------------------------
+CONF_RATIO = "ratio"
 CONF_ARTWORK_WIDTH = "artwork_width"
 CONF_ARTWORK_HEIGHT = "artwork_height"
 
-PROVIDER_ITUNES = "itunes"
-PROVIDER_MUSICBRAINZ = "musicbrainz"
-PROVIDER_TV = "tv"
-PROVIDER_BATTLENET = "battlenet"
-PROVIDER_STEAM = "steam"
+RATIO_1_1 = "1:1"
+RATIO_4_3 = "4:3"
+RATIO_16_9 = "16:9"
+RATIO_CUSTOM = "custom"
 
-DEFAULT_PROVIDERS: list[str] = [PROVIDER_ITUNES]
-DEFAULT_ARTWORK_SIZE = 600
+# (width, height) per preset key
+RATIO_DIMENSIONS: dict[str, tuple[int, int]] = {
+    RATIO_1_1: (600, 600),
+    RATIO_4_3: (800, 600),
+    RATIO_16_9: (960, 540),
+}
+
+# Legacy keys retained for migration only
+CONF_ARTWORK_SIZE = "artwork_size"
+
 DEFAULT_ARTWORK_WIDTH = 600
 DEFAULT_ARTWORK_HEIGHT = 600
+DEFAULT_ARTWORK_SIZE = 600
 
-# Combined Media Player feature
+# ---------------------------------------------------------------------------
+# Fallback artwork
+# ---------------------------------------------------------------------------
+CONF_FALLBACK_MODE = "fallback_mode"
+CONF_FALLBACK_CUSTOM_URL = "fallback_custom_url"
+
+FALLBACK_PLACEHOLDER = "placeholder"
+FALLBACK_SERVICE_LOGO = "service_logo"
+FALLBACK_CUSTOM_URL_MODE = "custom_url"
+
+# ---------------------------------------------------------------------------
+# Providers
+# ---------------------------------------------------------------------------
+CONF_PROVIDERS = "providers"
+
+PROVIDER_ITUNES = "itunes"
+PROVIDER_MUSICBRAINZ = "musicbrainz"
+PROVIDER_TMDB = "tmdb"
+PROVIDER_IGDB = "igdb"
+PROVIDER_STEAMGRIDDB = "steamgriddb"
+PROVIDER_STEAM = "steam"          # no-key fallback (Steam Store search)
+PROVIDER_TVMAZE = "tvmaze"
+PROVIDER_FANART = "fanart"
+# Legacy provider keys (kept for migration compatibility)
+PROVIDER_TV = "tv"
+PROVIDER_BATTLENET = "battlenet"
+
+DEFAULT_PROVIDERS: list[str] = [PROVIDER_ITUNES]
+
+# Category → ordered provider list (providers without required keys are skipped)
+CATEGORY_PROVIDERS: dict[str, list[str]] = {
+    CATEGORY_MUSIC: [PROVIDER_ITUNES, PROVIDER_MUSICBRAINZ],
+    CATEGORY_STREAMING: [PROVIDER_TMDB],
+    CATEGORY_GAMING: [PROVIDER_IGDB, PROVIDER_STEAMGRIDDB, PROVIDER_STEAM],
+    CATEGORY_TV: [PROVIDER_TVMAZE, PROVIDER_FANART],
+    CATEGORY_AUTO: [
+        PROVIDER_ITUNES,
+        PROVIDER_MUSICBRAINZ,
+        PROVIDER_TMDB,
+        PROVIDER_IGDB,
+        PROVIDER_STEAMGRIDDB,
+        PROVIDER_STEAM,
+        PROVIDER_TVMAZE,
+        PROVIDER_FANART,
+    ],
+}
+
+# Providers available for manual ordering (music + auto categories only)
+ORDERABLE_PROVIDERS: dict[str, list[str]] = {
+    CATEGORY_MUSIC: [PROVIDER_ITUNES, PROVIDER_MUSICBRAINZ],
+    CATEGORY_AUTO: [
+        PROVIDER_ITUNES,
+        PROVIDER_MUSICBRAINZ,
+        PROVIDER_TMDB,
+        PROVIDER_IGDB,
+        PROVIDER_STEAMGRIDDB,
+        PROVIDER_STEAM,
+        PROVIDER_TVMAZE,
+        PROVIDER_FANART,
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# API keys (always stored in entry.options, never in entry.data)
+# ---------------------------------------------------------------------------
+CONF_TMDB_API_KEY = "tmdb_api_key"
+CONF_IGDB_CLIENT_ID = "igdb_client_id"
+CONF_IGDB_CLIENT_SECRET = "igdb_client_secret"
+CONF_STEAMGRIDDB_API_KEY = "steamgriddb_api_key"
+CONF_FANART_API_KEY = "fanart_api_key"
+CONF_XMLTV_URL = "xmltv_url"  # stored but not yet used (EPG v3.1)
+
+# ---------------------------------------------------------------------------
+# Combined Player
+# ---------------------------------------------------------------------------
 CONF_CREATE_COMBINED = "create_combined"
 CONF_COMBINED_NAME = "combined_name"
 CONF_COMBINED_SOURCES = "combined_sources"
 CONF_COMBINED_AUDIO_SOURCES = "combined_audio_sources"
+CONF_AUTO_PRIORITY = "auto_priority"
 COMBINED_NUM_SOURCE_SLOTS = 8

--- a/custom_components/media_art_wrapper/helpers.py
+++ b/custom_components/media_art_wrapper/helpers.py
@@ -1,12 +1,78 @@
 from __future__ import annotations
 
 import base64
+import os
 
 # Shared fallback image (small PNG placeholder shown when no cover is available).
 # Used by both the Image and Camera entities to avoid duplicating the binary blob.
 FALLBACK_IMAGE = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAYAAADDPmHLAAABQUlEQVR42u3cMRGAMAAEwVeSGglowAqKcBY3QQAVM+l+izPAb8NAkvN6lnqLhwCABwGAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAO1vz/h0ApcM3QYjhuyHE+N0IYvhuCDF+N4IYvxsBAAAYvxlBjN+NAAAAjN+MAAAAjN+MAAAAAAAAAADaABxjfAIAAAAAAAAAAAAAwFsAAAAAAAAAAAAAga+BAAAAgT+CAAAAAn8FQ+BcAAAAQOBsoNPBALgfAAA3hADgjiAA3BIGgAAQAAJAAAgAASAABIAAEAACQAAIAAEgAASAABAAAkAACAABIAAEgAAQAAJAAAgAASAABIAAEAACQNt6Adpn9COM5b1AAAAAAElFTkSuQmCC"
 )
+
+# ---------------------------------------------------------------------------
+# Service logo mapping
+# ---------------------------------------------------------------------------
+
+# Base directory where service logo PNGs are stored
+_LOGO_DIR = os.path.join(os.path.dirname(__file__), "icons", "services")
+
+# app_name / category keyword → PNG filename stem (without extension)
+# Keys are lowercased for case-insensitive matching.
+_SERVICE_LOGO_MAP: dict[str, str] = {
+    # Music streaming
+    "apple music":      "apple_music",
+    "spotify":          "spotify",
+    "tidal":            "tidal",
+    "youtube music":    "youtube_music",
+    "amazon music":     "amazon_music",
+    "deezer":           "deezer",
+    "soundcloud":       "soundcloud",
+    # Video streaming
+    "netflix":          "netflix",
+    "disney+":          "disney_plus",
+    "disney plus":      "disney_plus",
+    "apple tv+":        "apple_tv_plus",
+    "apple tv plus":    "apple_tv_plus",
+    "amazon prime":     "amazon_prime",
+    "prime video":      "amazon_prime",
+    "hbo max":          "hbo_max",
+    "max":              "hbo_max",
+    "hulu":             "hulu",
+    "peacock":          "peacock",
+    "paramount+":       "paramount_plus",
+    "youtube":          "youtube",
+    "youtube tv":       "youtube_tv",
+    "twitch":           "twitch",
+    # Gaming platforms
+    "playstation":      "playstation",
+    "xbox":             "xbox",
+    "steam":            "steam",
+    "epic games":       "epic_games",
+    "epic":             "epic_games",
+    "gog":              "gog",
+    # Podcasts / radio
+    "pocket casts":     "pocket_casts",
+    "overcast":         "overcast",
+    "castro":           "castro",
+}
+
+
+def service_logo(app_name: str) -> bytes | None:
+    """Return PNG bytes for a known streaming service, or None.
+
+    *app_name* is matched case-insensitively against ``_SERVICE_LOGO_MAP``.
+    Returns ``None`` when the service is unknown or the logo file is missing.
+    """
+    key = (app_name or "").strip().lower()
+    stem = _SERVICE_LOGO_MAP.get(key)
+    if not stem:
+        return None
+    path = os.path.join(_LOGO_DIR, f"{stem}.png")
+    try:
+        with open(path, "rb") as f:
+            return f.read()
+    except OSError:
+        return None
 
 
 def source_name(source_entity_id: str) -> str:

--- a/custom_components/media_art_wrapper/image.py
+++ b/custom_components/media_art_wrapper/image.py
@@ -18,9 +18,13 @@ from .const import (
     CONF_COMBINED_NAME,
     CONF_COMBINED_SOURCES,
     CONF_CREATE_COMBINED,
+    CONF_FALLBACK_CUSTOM_URL,
+    CONF_FALLBACK_MODE,
     DOMAIN,
+    FALLBACK_CUSTOM_URL_MODE,
+    FALLBACK_SERVICE_LOGO,
 )
-from .helpers import FALLBACK_IMAGE, source_name
+from .helpers import FALLBACK_IMAGE, service_logo, source_name
 from .media_player import _TIER1, _TIER2, _TIER3, _safe_state
 
 
@@ -65,11 +69,40 @@ class MediaCoverArtImage(CoordinatorEntity[CoverCoordinator], ImageEntity):
 
     async def async_image(self) -> bytes | None:
         data: CoverData | None = self.coordinator.data
-        if not data or not data.image:
-            self._attr_content_type = "image/png"
-            return FALLBACK_IMAGE
-        self._attr_content_type = data.content_type or "image/jpeg"
-        return data.image
+        if data and data.image:
+            self._attr_content_type = data.content_type or "image/jpeg"
+            return data.image
+
+        # No artwork — apply the configured fallback mode
+        opts = self._entry.options
+        fallback_mode = opts.get(CONF_FALLBACK_MODE, "placeholder")
+
+        if fallback_mode == FALLBACK_SERVICE_LOGO:
+            # Try app_name from the source entity state
+            state = self.hass.states.get(self.coordinator.source_entity_id)
+            app_name = state.attributes.get("app_name", "") if state else ""
+            logo = service_logo(app_name) if app_name else None
+            if logo:
+                self._attr_content_type = "image/png"
+                return logo
+
+        if fallback_mode == FALLBACK_CUSTOM_URL_MODE:
+            custom_url = str(opts.get(CONF_FALLBACK_CUSTOM_URL, "")).strip()
+            if custom_url.startswith("http"):
+                try:
+                    session = aiohttp_client.async_get_clientsession(self.hass)
+                    async with session.get(custom_url, timeout=10) as resp:
+                        if resp.status == 200:
+                            ct = resp.headers.get("Content-Type", "image/jpeg")
+                            self._attr_content_type = ct.split(";")[0].strip()
+                            img = await resp.read()
+                            if img:
+                                return img
+                except Exception:
+                    pass
+
+        self._attr_content_type = "image/png"
+        return FALLBACK_IMAGE
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:

--- a/custom_components/media_art_wrapper/manifest.json
+++ b/custom_components/media_art_wrapper/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "media_art_wrapper",
   "name": "Media Art Wrapper",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "documentation": "https://github.com/Levtos/Media_Art_Wrapper",
   "issue_tracker": "https://github.com/Levtos/Media_Art_Wrapper/issues",
   "codeowners": [

--- a/custom_components/media_art_wrapper/media_player.py
+++ b/custom_components/media_art_wrapper/media_player.py
@@ -11,6 +11,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import CoverCoordinator, CoverData
 from .const import (
+    CATEGORY_SORT_PRIORITY,
+    CONF_AUTO_PRIORITY,
     CONF_COMBINED_AUDIO_SOURCES,
     CONF_COMBINED_NAME,
     CONF_COMBINED_SOURCES,
@@ -35,23 +37,47 @@ def _safe_state(raw: str) -> MediaPlayerState | None:
         return None
 
 
-def _get_combined_config(entry: ConfigEntry) -> tuple[bool, str, list[str], list[str]]:
-    """Return (create_combined, name, sources, audio_sources) from entry options/data."""
+def _get_combined_config(entry: ConfigEntry) -> tuple[bool, str, list[str], list[str], bool]:
+    """Return (create_combined, name, sources, audio_sources, auto_priority) from entry options/data."""
     opts = entry.options
     data = entry.data
     create = bool(opts.get(CONF_CREATE_COMBINED, data.get(CONF_CREATE_COMBINED, False)))
     name = str(opts.get(CONF_COMBINED_NAME, data.get(CONF_COMBINED_NAME, ""))).strip()
     sources: list[str] = list(opts.get(CONF_COMBINED_SOURCES, data.get(CONF_COMBINED_SOURCES, [])))
     audio: list[str] = list(opts.get(CONF_COMBINED_AUDIO_SOURCES, data.get(CONF_COMBINED_AUDIO_SOURCES, [])))
-    return create, name, sources, audio
+    auto_priority = bool(opts.get(CONF_AUTO_PRIORITY, data.get(CONF_AUTO_PRIORITY, True)))
+    return create, name, sources, audio, auto_priority
+
+
+def _sort_sources_by_category(
+    sources: list[str],
+    hass: HomeAssistant,
+) -> list[str]:
+    """Sort combined sources by their MAW coordinator's category priority.
+
+    Lower CATEGORY_SORT_PRIORITY number = higher priority in the sorted list.
+    Sources without a MAW coordinator (non-MAW media players) keep their
+    original relative order at the end with priority=999.
+    """
+    # Build a map of source entity_id → category priority from active MAW coordinators
+    cat_priority: dict[str, int] = {}
+    for coordinator in hass.data.get(DOMAIN, {}).values():
+        if isinstance(coordinator, CoverCoordinator):
+            priority = CATEGORY_SORT_PRIORITY.get(coordinator.category, 999)
+            cat_priority[coordinator.source_entity_id] = priority
+
+    # Stable sort: sources without a coordinator keep their original order at end
+    return sorted(sources, key=lambda sid: cat_priority.get(sid, 999))
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities) -> None:
     coordinator: CoverCoordinator = hass.data[DOMAIN][entry.entry_id]
     entities: list[MediaPlayerEntity] = [MediaCoverArtUniversalPlayer(coordinator, entry)]
 
-    create_combined, combined_name, combined_sources, combined_audio = _get_combined_config(entry)
+    create_combined, combined_name, combined_sources, combined_audio, auto_priority = _get_combined_config(entry)
     if create_combined and combined_name and combined_sources:
+        if auto_priority:
+            combined_sources = _sort_sources_by_category(combined_sources, hass)
         entities.append(CombinedMediaPlayer(hass, entry, combined_sources, combined_audio, combined_name))
 
     async_add_entities(entities, update_before_add=False)

--- a/custom_components/media_art_wrapper/providers/__init__.py
+++ b/custom_components/media_art_wrapper/providers/__init__.py
@@ -1,0 +1,125 @@
+"""providers/ — artwork provider registry and resolution pipeline.
+
+Public API
+----------
+get_providers(category, options) -> list[ArtworkProvider]
+    Build an ordered list of ArtworkProvider instances for the given category
+    and config entry options dict.  Providers whose credentials are missing
+    are silently omitted via is_available().
+
+resolve_cover(session, query, providers) -> ArtworkResult | None
+    Try each provider in order; return the first successful ArtworkResult.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..const import (
+    CATEGORY_AUTO,
+    CATEGORY_GAMING,
+    CATEGORY_MUSIC,
+    CATEGORY_PROVIDERS,
+    CATEGORY_STREAMING,
+    CATEGORY_TV,
+    CONF_FANART_API_KEY,
+    CONF_IGDB_CLIENT_ID,
+    CONF_IGDB_CLIENT_SECRET,
+    CONF_STEAMGRIDDB_API_KEY,
+    CONF_TMDB_API_KEY,
+)
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+from .fanart import FanartTvProvider
+from .igdb import IGDBProvider
+from .itunes import ITunesProvider
+from .musicbrainz import MusicBrainzProvider
+from .steamgriddb import SteamGridDBProvider, SteamProvider
+from .tmdb import TMDbProvider
+from .tvmaze import TVMazeProvider
+
+__all__ = [
+    "ArtworkProvider",
+    "ArtworkQuery",
+    "ArtworkResult",
+    "get_providers",
+    "resolve_cover",
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_providers(
+    category: str,
+    options: dict[str, Any],
+) -> list[ArtworkProvider]:
+    """Return an ordered list of available providers for *category*.
+
+    Providers that require credentials are instantiated with the values from
+    *options*; those whose ``is_available()`` returns False are excluded.
+
+    The order follows ``CATEGORY_PROVIDERS[category]``.
+    """
+    wanted: list[str] = CATEGORY_PROVIDERS.get(category, CATEGORY_PROVIDERS[CATEGORY_AUTO])
+
+    # Build all provider instances (keyed by provider name)
+    all_instances: dict[str, ArtworkProvider] = {
+        "itunes": ITunesProvider(),
+        "musicbrainz": MusicBrainzProvider(),
+        "tmdb": TMDbProvider(options.get(CONF_TMDB_API_KEY, "")),
+        "igdb": IGDBProvider(
+            options.get(CONF_IGDB_CLIENT_ID, ""),
+            options.get(CONF_IGDB_CLIENT_SECRET, ""),
+        ),
+        "steamgriddb": SteamGridDBProvider(options.get(CONF_STEAMGRIDDB_API_KEY, "")),
+        "steam": SteamProvider(),
+        "tvmaze": TVMazeProvider(),
+        "fanart": FanartTvProvider(options.get(CONF_FANART_API_KEY, "")),
+    }
+
+    result: list[ArtworkProvider] = []
+    for name in wanted:
+        provider = all_instances.get(name)
+        if provider is None:
+            _LOGGER.debug("Unknown provider %r skipped", name)
+            continue
+        if not provider.is_available():
+            _LOGGER.debug("Provider %r not available (missing credentials)", name)
+            continue
+        result.append(provider)
+
+    return result
+
+
+async def resolve_cover(
+    session,
+    query: ArtworkQuery,
+    providers: list[ArtworkProvider],
+) -> ArtworkResult | None:
+    """Try each provider in order; return the first successful ArtworkResult.
+
+    Providers are tried in the order supplied by *providers*.  If a provider
+    raises an unexpected exception it is logged and skipped so that the next
+    provider can be tried.
+    """
+    for provider in providers:
+        try:
+            result = await provider.fetch(session, query)
+        except Exception as err:
+            _LOGGER.debug(
+                "Provider %s raised an exception: %s",
+                type(provider).__name__,
+                err,
+            )
+            continue
+
+        if result is not None:
+            _LOGGER.debug(
+                "Artwork resolved by %r (url=%s, confidence=%.2f)",
+                result.provider_name,
+                result.image_url,
+                result.confidence,
+            )
+            return result
+
+    _LOGGER.debug("No provider returned artwork for query: title=%r artist=%r", query.title, query.artist)
+    return None

--- a/custom_components/media_art_wrapper/providers/base.py
+++ b/custom_components/media_art_wrapper/providers/base.py
@@ -1,0 +1,63 @@
+"""Abstract base classes and data models for MAW artwork providers."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class ArtworkQuery:
+    """All information available for an artwork lookup."""
+
+    title: str | None
+    artist: str | None = None
+    album: str | None = None
+    content_type: str | None = None   # media_content_type HA attribute
+    app_name: str | None = None       # app_name HA attribute
+    category: str = "auto"
+    artwork_width: int = 600
+    artwork_height: int = 600
+    # Raw title before remix/edit stripping (e.g. "Song (Remix)" vs "Song")
+    original_title: str | None = None
+    # Series title for episode content
+    series_title: str | None = None
+
+
+@dataclass(slots=True)
+class ArtworkResult:
+    """Successful artwork lookup result."""
+
+    provider_name: str
+    image_url: str | None             # Public CDN URL if available
+    confidence: float = 1.0           # 0.0–1.0; first-match wins, but stored for diagnostics
+    image: bytes | None = None        # Fetched image bytes
+    content_type: str = "image/jpeg"
+
+
+class ArtworkProvider(ABC):
+    """Abstract base class for all artwork providers.
+
+    Subclasses declare which categories they serve via the ``categories``
+    class attribute and implement ``fetch()``.
+    """
+
+    # frozenset of category strings this provider handles.
+    # Always include "auto" if the provider should be tried for the catch-all category.
+    categories: frozenset[str] = frozenset({"auto"})
+
+    def is_available(self) -> bool:
+        """Return True when all required API credentials are configured.
+
+        Override this in providers that require API keys.  The coordinator
+        will skip providers where is_available() returns False.
+        """
+        return True
+
+    @abstractmethod
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        """Fetch artwork for *query* using *session* (aiohttp ClientSession).
+
+        Return an ArtworkResult on success, or None if no artwork was found.
+        Raise an exception only for unexpected errors (network failures, etc.);
+        a "no results" outcome should return None silently.
+        """

--- a/custom_components/media_art_wrapper/providers/epg_base.py
+++ b/custom_components/media_art_wrapper/providers/epg_base.py
@@ -1,0 +1,60 @@
+"""EPG (Electronic Programme Guide) provider base — stub for future XMLTV support."""
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EPGProvider(ABC):
+    """Abstract base class for EPG data sources.
+
+    An EPG provider answers the question: "What is currently airing on
+    channel X?", returning structured programme metadata.
+    """
+
+    @abstractmethod
+    async def get_current_program(
+        self,
+        session,
+        channel_name: str,
+    ) -> dict[str, Any] | None:
+        """Return metadata for the programme currently airing on *channel_name*.
+
+        Returns a dict with keys:
+            title     – episode/programme title (may be empty string)
+            show_name – series/show name
+            image_url – URL of the best available image, or None
+        or None if no current programme can be found.
+        """
+
+
+class XmltvEpgProvider(EPGProvider):
+    """EPG provider backed by a remote XMLTV feed.
+
+    TODO (v3.1): implement XMLTV parsing and channel/programme matching.
+    This stub always returns None so that the TV provider falls through
+    to its other artwork sources (TVMaze schedule, Wikipedia, etc.).
+    """
+
+    def __init__(self, xmltv_url: str) -> None:
+        self._xmltv_url = (xmltv_url or "").strip()
+
+    def is_available(self) -> bool:
+        return bool(self._xmltv_url)
+
+    async def get_current_program(
+        self,
+        session,
+        channel_name: str,
+    ) -> dict[str, Any] | None:
+        # TODO (v3.1): fetch and parse XMLTV feed, match channel_name,
+        # return currently-airing programme metadata.
+        _LOGGER.debug(
+            "XmltvEpgProvider: XMLTV support not yet implemented (url=%r, channel=%r)",
+            self._xmltv_url,
+            channel_name,
+        )
+        return None

--- a/custom_components/media_art_wrapper/providers/fanart.py
+++ b/custom_components/media_art_wrapper/providers/fanart.py
@@ -1,0 +1,215 @@
+"""Fanart.tv provider — TV show and music artist artwork."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+
+TVMAZE_SEARCH_URL = "https://api.tvmaze.com/search/shows"
+FANART_TV_URL = "https://webservice.fanart.tv/v3/tv/{tvdb_id}"
+FANART_MUSIC_URL = "https://webservice.fanart.tv/v3/music/{mbid}"
+MUSICBRAINZ_ARTIST_URL = "https://musicbrainz.org/ws/2/artist"
+_JSON_KW = {"content_type": None}
+_UA = "media-art-wrapper-ha/3.0 (+https://github.com/Levtos/Media_Art_Wrapper)"
+
+# Art type preference order for TV: hdtvlogo > clearlogo > tvposter > tvthumb
+_TV_ART_KEYS = ("hdtvlogo", "clearlogo", "tvposter", "tvthumb", "showbackground")
+# Art type preference order for music: artistthumb > artistbackground
+_MUSIC_ART_KEYS = ("artistthumb", "artistbackground", "albumcover")
+
+
+def _pick_best(images: list[dict[str, Any]]) -> str | None:
+    """Return the URL of the highest-liked image from a fanart.tv image list."""
+    if not images:
+        return None
+    best = max(
+        (img for img in images if isinstance(img, dict) and img.get("url")),
+        key=lambda x: int(x.get("likes", 0)),
+        default=None,
+    )
+    url = best.get("url") if best else None
+    return str(url) if isinstance(url, str) and url else None
+
+
+class FanartTvProvider(ArtworkProvider):
+    """Fanart.tv — high-quality TV show logos/posters and music artist images."""
+
+    categories = frozenset({"streaming", "tv", "music", "auto"})
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = (api_key or "").strip()
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        if query.category in ("music",):
+            return await self._fetch_music(session, query)
+        return await self._fetch_tv(session, query)
+
+    # ------------------------------------------------------------------
+    async def _fetch_tv(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        """Fetch TV show poster/logo via TVMaze TVDB ID → Fanart.tv."""
+        title = (query.title or query.series_title or "").strip()
+        if not title:
+            return None
+
+        # Step 1: Resolve TVDB ID from TVMaze (no key required)
+        tvdb_id = await self._tvmaze_tvdb_id(session, title)
+        if not tvdb_id:
+            return None
+
+        # Step 2: Fetch fanart.tv TV metadata
+        url = FANART_TV_URL.format(tvdb_id=tvdb_id)
+        try:
+            async with session.get(
+                url,
+                params={"api_key": self._api_key},
+                timeout=10,
+            ) as resp:
+                if resp.status == 404:
+                    return None
+                resp.raise_for_status()
+                data: dict[str, Any] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("Fanart.tv TV fetch failed for TVDB=%s: %s", tvdb_id, err)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        # Try art types in preference order
+        art_url: str | None = None
+        for key in _TV_ART_KEYS:
+            images = data.get(key)
+            if isinstance(images, list):
+                art_url = _pick_best(images)
+                if art_url:
+                    break
+
+        if not art_url:
+            return None
+
+        return await self._download(session, art_url, "fanart_tv")
+
+    # ------------------------------------------------------------------
+    async def _fetch_music(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        """Fetch music artist image via MusicBrainz MBID → Fanart.tv."""
+        artist = (query.artist or "").strip()
+        if not artist:
+            return None
+
+        mbid = await self._musicbrainz_artist_mbid(session, artist)
+        if not mbid:
+            return None
+
+        url = FANART_MUSIC_URL.format(mbid=mbid)
+        try:
+            async with session.get(
+                url,
+                params={"api_key": self._api_key},
+                timeout=10,
+            ) as resp:
+                if resp.status == 404:
+                    return None
+                resp.raise_for_status()
+                data: dict[str, Any] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("Fanart.tv music fetch failed for MBID=%s: %s", mbid, err)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        art_url: str | None = None
+        for key in _MUSIC_ART_KEYS:
+            images = data.get(key)
+            if isinstance(images, list):
+                art_url = _pick_best(images)
+                if art_url:
+                    break
+
+        if not art_url:
+            return None
+
+        return await self._download(session, art_url, "fanart_tv_music")
+
+    # ------------------------------------------------------------------
+    async def _tvmaze_tvdb_id(self, session, title: str) -> str | None:
+        """Search TVMaze for a show and return its TheTVDB external ID."""
+        try:
+            async with session.get(
+                TVMAZE_SEARCH_URL,
+                params={"q": title},
+                timeout=10,
+            ) as resp:
+                resp.raise_for_status()
+                results: list[dict[str, Any]] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("TVMaze search failed for %r: %s", title, err)
+            return None
+
+        if not isinstance(results, list) or not results:
+            return None
+
+        for entry in results:
+            if not isinstance(entry, dict):
+                continue
+            show = entry.get("show")
+            if not isinstance(show, dict):
+                continue
+            externals = show.get("externals") or {}
+            tvdb = externals.get("thetvdb")
+            if tvdb:
+                return str(tvdb)
+
+        return None
+
+    async def _musicbrainz_artist_mbid(self, session, artist: str) -> str | None:
+        """Return MusicBrainz artist MBID for the given artist name."""
+        try:
+            async with session.get(
+                MUSICBRAINZ_ARTIST_URL,
+                params={"query": f'artist:"{artist}"', "fmt": "json", "limit": "1"},
+                headers={"User-Agent": _UA},
+                timeout=10,
+            ) as resp:
+                resp.raise_for_status()
+                payload: dict[str, Any] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("MusicBrainz artist lookup failed for %r: %s", artist, err)
+            return None
+
+        artists = payload.get("artists") if isinstance(payload, dict) else None
+        if not isinstance(artists, list) or not artists:
+            return None
+        first = artists[0]
+        if not isinstance(first, dict):
+            return None
+        return first.get("id")
+
+    async def _download(
+        self, session, url: str, provider_name: str
+    ) -> ArtworkResult | None:
+        try:
+            async with session.get(url, timeout=10) as resp:
+                resp.raise_for_status()
+                ct = resp.headers.get("Content-Type", "image/jpeg")
+                image = await resp.read()
+        except Exception as err:
+            _LOGGER.debug("Fanart.tv image download failed (%s): %s", url, err)
+            return None
+
+        if not image:
+            return None
+
+        return ArtworkResult(
+            provider_name=provider_name,
+            image_url=url,
+            confidence=0.88,
+            image=image,
+            content_type=ct,
+        )

--- a/custom_components/media_art_wrapper/providers/igdb.py
+++ b/custom_components/media_art_wrapper/providers/igdb.py
@@ -1,0 +1,153 @@
+"""IGDB (Twitch) provider — game cover art."""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+
+TWITCH_TOKEN_URL = "https://id.twitch.tv/oauth2/token"
+IGDB_GAMES_URL = "https://api.igdb.com/v4/games"
+IGDB_COVERS_URL = "https://api.igdb.com/v4/covers"
+_JSON_KW = {"content_type": None}
+
+# Access token is cached across requests for its lifetime
+_token_cache: dict[str, Any] = {}  # {client_id: {"token": str, "expires_at": float}}
+
+
+async def _get_access_token(session, client_id: str, client_secret: str) -> str | None:
+    """Return a cached or freshly-acquired Twitch OAuth2 access token."""
+    cached = _token_cache.get(client_id)
+    if cached and time.time() < cached["expires_at"] - 60:
+        return cached["token"]
+
+    try:
+        async with session.post(
+            TWITCH_TOKEN_URL,
+            params={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "grant_type": "client_credentials",
+            },
+            timeout=10,
+        ) as resp:
+            resp.raise_for_status()
+            data: dict[str, Any] = await resp.json(**_JSON_KW)
+    except Exception as err:
+        _LOGGER.debug("IGDB token request failed: %s", err)
+        return None
+
+    token = data.get("access_token")
+    expires_in = int(data.get("expires_in", 3600))
+    if not isinstance(token, str):
+        return None
+
+    _token_cache[client_id] = {"token": token, "expires_at": time.time() + expires_in}
+    return token
+
+
+class IGDBProvider(ArtworkProvider):
+    """IGDB game cover art via Twitch Developer credentials."""
+
+    categories = frozenset({"gaming", "auto"})
+
+    def __init__(self, client_id: str, client_secret: str) -> None:
+        self._client_id = (client_id or "").strip()
+        self._client_secret = (client_secret or "").strip()
+
+    def is_available(self) -> bool:
+        return bool(self._client_id and self._client_secret)
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        title = (query.title or "").strip()
+        if not title:
+            return None
+
+        token = await _get_access_token(session, self._client_id, self._client_secret)
+        if not token:
+            return None
+
+        headers = {
+            "Client-ID": self._client_id,
+            "Authorization": f"Bearer {token}",
+        }
+
+        # Search for the game
+        search_body = f'search "{title}"; fields id,name,cover; limit 5;'
+        try:
+            async with session.post(
+                IGDB_GAMES_URL,
+                headers=headers,
+                data=search_body,
+                timeout=10,
+            ) as resp:
+                resp.raise_for_status()
+                games: list[dict[str, Any]] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("IGDB game search failed for %r: %s", title, err)
+            return None
+
+        if not isinstance(games, list) or not games:
+            return None
+
+        # Pick the first game that has a cover ID
+        cover_id: int | None = None
+        for game in games:
+            if not isinstance(game, dict):
+                continue
+            cid = game.get("cover")
+            if isinstance(cid, int):
+                cover_id = cid
+                break
+
+        if cover_id is None:
+            return None
+
+        # Fetch cover URL
+        cover_body = f"fields image_id; where id = {cover_id};"
+        try:
+            async with session.post(
+                IGDB_COVERS_URL,
+                headers=headers,
+                data=cover_body,
+                timeout=10,
+            ) as resp:
+                resp.raise_for_status()
+                covers: list[dict[str, Any]] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("IGDB cover fetch failed: %s", err)
+            return None
+
+        if not isinstance(covers, list) or not covers:
+            return None
+
+        image_id = covers[0].get("image_id") if isinstance(covers[0], dict) else None
+        if not isinstance(image_id, str):
+            return None
+
+        # t_cover_big = 264×374; t_original for highest quality
+        size = "t_cover_big_2x" if max(query.artwork_width, query.artwork_height) > 400 else "t_cover_big"
+        url = f"https://images.igdb.com/igdb/image/upload/{size}/{image_id}.jpg"
+
+        try:
+            async with session.get(url, timeout=10) as resp:
+                resp.raise_for_status()
+                ct = resp.headers.get("Content-Type", "image/jpeg")
+                image = await resp.read()
+        except Exception as err:
+            _LOGGER.debug("IGDB image download failed: %s", err)
+            return None
+
+        if not image:
+            return None
+
+        return ArtworkResult(
+            provider_name="igdb",
+            image_url=url,
+            confidence=0.95,
+            image=image,
+            content_type=ct,
+        )

--- a/custom_components/media_art_wrapper/providers/itunes.py
+++ b/custom_components/media_art_wrapper/providers/itunes.py
@@ -1,0 +1,204 @@
+"""iTunes Search API provider — music and TV/movie artwork."""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+ITUNES_SEARCH_URL = "https://itunes.apple.com/search"
+_JSON_KW = {"content_type": None}
+_RE_ARTWORK_SIZE = re.compile(r"/(\d{2,4})x(\d{2,4})bb\.(jpg|png)$", re.IGNORECASE)
+
+_RE_PAREN_FEAT = re.compile(r"\((feat\.|featuring|ft\.|remix|edit|mix).*?\)", re.IGNORECASE)
+_RE_BRACKET_FEAT = re.compile(r"\[(feat\.|featuring|ft\.|remix|edit|mix).*?\]", re.IGNORECASE)
+_RE_BARE_FEAT = re.compile(r"\s+(?:feat\.|featuring|ft\.)\s+.*$", re.IGNORECASE)
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RE_SPACES = re.compile(r"\s+")
+
+
+def _search_term(s: str) -> str:
+    s = s.strip()
+    s = _RE_BARE_FEAT.sub("", s)
+    s = _RE_PAREN_FEAT.sub("", s)
+    s = _RE_BRACKET_FEAT.sub("", s)
+    return _RE_SPACES.sub(" ", s).strip()
+
+
+def _clean_score(s: str) -> str:
+    s = s.strip().lower()
+    s = _RE_BARE_FEAT.sub("", s)
+    s = _RE_PAREN_FEAT.sub("", s)
+    s = _RE_BRACKET_FEAT.sub("", s)
+    s = _RE_NON_ALNUM.sub(" ", s)
+    return _RE_SPACES.sub(" ", s).strip()
+
+
+def _score_music(query: ArtworkQuery, item: dict[str, Any]) -> int:
+    q_artist = _clean_score(query.artist or "")
+    q_title = _clean_score(query.title or "")
+    q_album = _clean_score(query.album or "")
+    r_artist = _clean_score(str(item.get("artistName", "")))
+    r_title = _clean_score(str(item.get("trackName", "")))
+    r_album = _clean_score(str(item.get("collectionName", "")))
+    score = 0
+    if q_title and r_title:
+        if q_title == r_title:
+            score += 16
+        elif q_title in r_title or r_title in q_title:
+            score += 7
+        else:
+            score -= 8
+    if q_artist and r_artist:
+        if q_artist == r_artist:
+            score += 14
+        elif q_artist in r_artist or r_artist in q_artist:
+            score += 5
+        else:
+            score -= 6
+    if q_album and r_album:
+        if q_album == r_album:
+            score += 6
+        elif q_album in r_album or r_album in q_album:
+            score += 3
+    if "single" in r_album:
+        score += 3
+    if str(item.get("wrapperType", "")).lower() == "track":
+        score += 1
+    return score
+
+
+def _upscale(url: str, size: int) -> str:
+    m = _RE_ARTWORK_SIZE.search(url)
+    if not m:
+        return url
+    return _RE_ARTWORK_SIZE.sub(f"/{size}x{size}bb.{m.group(3)}", url)
+
+
+async def _search(session, term: str, entity: str = "song", media: str = "music") -> list[dict[str, Any]]:
+    params = {"term": term, "entity": entity, "media": media, "limit": "15"}
+    async with session.get(ITUNES_SEARCH_URL, params=params, timeout=10) as resp:
+        resp.raise_for_status()
+        payload = await resp.json(**_JSON_KW)
+    results = payload.get("results") if isinstance(payload, dict) else None
+    return [r for r in results if isinstance(r, dict)] if isinstance(results, list) else []
+
+
+class ITunesProvider(ArtworkProvider):
+    """iTunes Search API — music tracks, TV shows, movies."""
+
+    categories = frozenset({"music", "auto"})
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        if not (query.artist or query.title):
+            return None
+
+        category = query.category
+        if category in ("streaming", "tv"):
+            return await self._fetch_video(session, query)
+        return await self._fetch_music(session, query)
+
+    # ------------------------------------------------------------------
+    async def _fetch_music(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        terms = []
+        t1 = " ".join(filter(None, [_search_term(query.artist or ""), _search_term(query.title or "")]))
+        if t1:
+            terms.append(t1)
+        t2 = " ".join(filter(None, [_search_term(query.title or ""), _search_term(query.artist or "")]))
+        if t2 and t2 != t1:
+            terms.append(t2)
+        if query.title:
+            single = f"{_search_term(query.artist or '')} {_search_term(query.title)} single".strip()
+            terms.append(single)
+
+        results: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for term in terms:
+            try:
+                for item in await _search(session, term, entity="song", media="music"):
+                    iid = str(item.get("trackId") or item.get("collectionId") or id(item))
+                    if iid not in seen:
+                        seen.add(iid)
+                        results.append(item)
+            except Exception:
+                pass
+
+        if not results:
+            return None
+
+        best = max(results, key=lambda r: _score_music(query, r))
+        best_score = _score_music(query, best)
+        min_score = 12 if (query.artist and query.title) else (10 if query.title else 4)
+        if best_score < min_score:
+            return None
+
+        artwork = best.get("artworkUrl100") or best.get("artworkUrl60") or best.get("artworkUrl30")
+        if not isinstance(artwork, str):
+            return None
+
+        target = max(100, int(max(query.artwork_width, query.artwork_height)))
+        url = _upscale(artwork, target)
+        try:
+            async with session.get(url, timeout=10) as r:
+                r.raise_for_status()
+                ct = r.headers.get("Content-Type", "image/jpeg")
+                image = await r.read()
+        except Exception:
+            return None
+
+        return ArtworkResult(
+            provider_name="itunes",
+            image_url=url,
+            confidence=min(1.0, best_score / 30),
+            image=image,
+            content_type=ct,
+        )
+
+    # ------------------------------------------------------------------
+    async def _fetch_video(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        """Fetch TV/movie artwork (used internally by TVMazeProvider cascade)."""
+        term = query.title or ""
+        if not term:
+            return None
+
+        try:
+            results = await _search(session, term, entity="tvShow,movie", media="video")
+        except Exception:
+            return None
+
+        def _name_overlap(a: str, b: str) -> bool:
+            ca = _clean_score(a)
+            cb = _clean_score(b)
+            return bool(ca and cb and (ca in cb or cb in ca))
+
+        for item in results:
+            result_name = str(item.get("trackName") or item.get("collectionName") or "")
+            if not _name_overlap(term, result_name):
+                continue
+            artwork = item.get("artworkUrl100") or item.get("artworkUrl60") or item.get("artworkUrl30")
+            if not isinstance(artwork, str):
+                continue
+            target = max(100, int(max(query.artwork_width, query.artwork_height)))
+            url = re.sub(
+                r"/(\d{2,4})x(\d{2,4})bb\.(jpg|png)$",
+                f"/{target}x{target}bb.jpg",
+                artwork,
+                flags=re.IGNORECASE,
+            )
+            try:
+                async with session.get(url, timeout=10) as r:
+                    r.raise_for_status()
+                    ct = r.headers.get("Content-Type", "image/jpeg")
+                    image = await r.read()
+                    if image:
+                        return ArtworkResult(
+                            provider_name="itunes_tv",
+                            image_url=url,
+                            confidence=0.7,
+                            image=image,
+                            content_type=ct,
+                        )
+            except Exception:
+                continue
+
+        return None

--- a/custom_components/media_art_wrapper/providers/musicbrainz.py
+++ b/custom_components/media_art_wrapper/providers/musicbrainz.py
@@ -1,0 +1,84 @@
+"""MusicBrainz + Cover Art Archive provider."""
+from __future__ import annotations
+
+import logging
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+
+MB_SEARCH_URL = "https://musicbrainz.org/ws/2/recording"
+CAA_FRONT_URL = "https://coverartarchive.org/release/{release_id}/front-500"
+_JSON_KW = {"content_type": None}
+_UA = "media-art-wrapper-ha/3.0 (+https://github.com/Levtos/Media_Art_Wrapper)"
+
+
+class MusicBrainzProvider(ArtworkProvider):
+    """MusicBrainz recording search + Cover Art Archive image fetch."""
+
+    categories = frozenset({"music", "auto"})
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        if not (query.artist or query.title):
+            return None
+
+        fragments: list[str] = []
+        if query.title:
+            fragments.append(f'recording:"{query.title}"')
+        if query.artist:
+            fragments.append(f'artist:"{query.artist}"')
+        mb_query = " AND ".join(fragments)
+
+        try:
+            async with session.get(
+                MB_SEARCH_URL,
+                params={"query": mb_query, "fmt": "json", "limit": "5"},
+                headers={"User-Agent": _UA},
+                timeout=10,
+            ) as resp:
+                resp.raise_for_status()
+                payload = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("MusicBrainz search failed: %s", err)
+            return None
+
+        recordings = payload.get("recordings") if isinstance(payload, dict) else None
+        if not isinstance(recordings, list):
+            return None
+
+        release_id: str | None = None
+        for rec in recordings:
+            if not isinstance(rec, dict):
+                continue
+            for rel in rec.get("releases") or []:
+                rid = rel.get("id") if isinstance(rel, dict) else None
+                if isinstance(rid, str) and rid:
+                    release_id = rid
+                    break
+            if release_id:
+                break
+
+        if not release_id:
+            return None
+
+        url = CAA_FRONT_URL.format(release_id=release_id)
+        try:
+            async with session.get(url, timeout=10) as resp:
+                if resp.status >= 400:
+                    return None
+                ct = resp.headers.get("Content-Type", "image/jpeg")
+                image = await resp.read()
+        except Exception as err:
+            _LOGGER.debug("Cover Art Archive fetch failed: %s", err)
+            return None
+
+        if not image:
+            return None
+
+        return ArtworkResult(
+            provider_name="musicbrainz",
+            image_url=url,
+            confidence=0.85,
+            image=image,
+            content_type=ct,
+        )

--- a/custom_components/media_art_wrapper/providers/query_builder.py
+++ b/custom_components/media_art_wrapper/providers/query_builder.py
@@ -1,0 +1,142 @@
+"""Category-specific query construction.
+
+build_query() is the single entry point: given raw HA state attributes and
+the configured category, it returns an ArtworkQuery ready for the providers.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from .base import ArtworkQuery
+
+# ---------------------------------------------------------------------------
+# Text helpers (mirrors __init__.py but kept local to avoid circular imports)
+# ---------------------------------------------------------------------------
+
+_RE_CLEAN = re.compile(
+    r"""
+       \s*
+       (
+           \([^)]*(?:Remix|Edit|Mix)[^)]*\) |
+           \[[^\]]*(?:Remix|Edit|Mix)[^\]]*\] |
+           -\s*.*(?:Remix|Edit|Mix).* |
+           \(?\s*\d+[_:]\d+\s*\)?
+       )
+    """,
+    re.I | re.X,
+)
+_RE_SPACES = re.compile(r"\s{2,}")
+_BAD = {"", "none", "null", "unknown", "n/a", "-"}
+
+# Platform suffixes to strip from gaming titles
+_RE_PLATFORM_SUFFIX = re.compile(
+    r"\s*[-–|]\s*(?:PS\s*[2345]|PlayStation\s*[2345]?|Xbox(?:\s*One|\s*Series\s*[XS])?|"
+    r"PC|Nintendo\s*Switch|Switch|Steam|Epic)\s*$",
+    re.IGNORECASE,
+)
+
+# Broadcast-quality / regional suffixes for TV channel names
+_RE_CHANNEL_SUFFIX = re.compile(
+    r"\s+\b(hd|sd|uhd|4k|hbbtv)\b.*$",
+    re.IGNORECASE,
+)
+
+
+def _raw(value: Any) -> str | None:
+    """Normalise whitespace only – keeps remix/edit annotations."""
+    if not isinstance(value, str):
+        return None
+    s = _RE_SPACES.sub(" ", value).strip()
+    return s if s.lower() not in _BAD else None
+
+
+def _clean(value: Any) -> str | None:
+    """Strip remix/edit annotations and normalise whitespace."""
+    if not isinstance(value, str):
+        return None
+    s = _RE_SPACES.sub(" ", _RE_CLEAN.sub("", value)).strip()
+    return s if s.lower() not in _BAD else None
+
+
+def _strip_platform(title: str) -> str:
+    return _RE_PLATFORM_SUFFIX.sub("", title).strip()
+
+
+def _strip_channel(name: str) -> str:
+    return _RE_CHANNEL_SUFFIX.sub("", name).strip()
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def build_query(
+    state_attrs: dict[str, Any],
+    category: str,
+    artwork_width: int = 600,
+    artwork_height: int = 600,
+) -> ArtworkQuery:
+    """Build an ArtworkQuery from HA media_player state attributes.
+
+    Category-specific transformations are applied before the query is returned:
+
+    - music  : Strip remix/edit annotations from both title slots; pass artist.
+    - streaming: Artist irrelevant; use series_title for episodes if title absent.
+    - gaming : Strip platform suffixes from title; artist irrelevant.
+    - tv     : Channel-name suffix stripped; app_name used as fallback title.
+    - auto   : Minimal transformation; let each provider decide what to use.
+    """
+    raw_title = _raw(state_attrs.get("media_title"))
+    clean_title = _clean(state_attrs.get("media_title"))
+    artist = _clean(state_attrs.get("media_artist"))
+    album = _clean(state_attrs.get("media_album_name"))
+    content_type = state_attrs.get("media_content_type")
+    app_name = _raw(state_attrs.get("app_name"))
+    series_title = _clean(state_attrs.get("media_series_title"))
+
+    title = clean_title
+    original = raw_title if (raw_title and raw_title != clean_title) else None
+
+    if category == "music":
+        # Keep remix/edit in original_title so providers can find remix-specific
+        # covers, but also try cleaned title as fallback.
+        pass  # already handled by raw vs. clean split above
+
+    elif category == "streaming":
+        artist = None  # not relevant for films/series
+        # For episodes, use series title as the primary search target
+        if content_type == "episode" and series_title:
+            if not title:
+                title = series_title
+            # Always expose series_title so providers can use it
+
+    elif category == "gaming":
+        artist = None
+        if title:
+            title = _strip_platform(title)
+        if original:
+            original = _strip_platform(original)
+
+    elif category == "tv":
+        # Use app_name as channel-name hint when title is absent
+        if not title and app_name:
+            title = app_name
+        # Strip broadcast-quality suffix (HD/SD) for cleaner matching
+        if title:
+            title = _strip_channel(title)
+
+    # For "auto": pass everything through and let providers decide
+
+    return ArtworkQuery(
+        title=title,
+        original_title=original,
+        artist=artist,
+        album=album,
+        content_type=content_type,
+        app_name=app_name,
+        category=category,
+        artwork_width=artwork_width,
+        artwork_height=artwork_height,
+        series_title=series_title,
+    )

--- a/custom_components/media_art_wrapper/providers/steamgriddb.py
+++ b/custom_components/media_art_wrapper/providers/steamgriddb.py
@@ -1,0 +1,260 @@
+"""SteamGridDB + Steam Store provider — game cover art."""
+from __future__ import annotations
+
+import logging
+import re
+import time
+from typing import Any
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+
+SGDB_SEARCH_URL = "https://www.steamgriddb.com/api/v2/search/autocomplete/{term}"
+SGDB_GRIDS_URL = "https://www.steamgriddb.com/api/v2/grids/game/{game_id}"
+_JSON_KW = {"content_type": None}
+
+# Steam public search-suggest endpoint (no API key needed)
+_STEAM_SUGGEST_URL = "https://store.steampowered.com/search/suggest"
+
+# Steam CDN image templates, tried in order (best quality first)
+_STEAM_IMAGE_TEMPLATES = [
+    "https://cdn.cloudflare.steamstatic.com/steam/apps/{appid}/library_600x900_2x.jpg",
+    "https://cdn.cloudflare.steamstatic.com/steam/apps/{appid}/library_600x900.jpg",
+    "https://cdn.cloudflare.steamstatic.com/steam/apps/{appid}/header.jpg",
+]
+
+# App-ID cache: normalised_title → (appid, fetched_at)
+_APPID_CACHE: dict[str, tuple[int, float]] = {}
+_APPID_CACHE_TTL = 86_400  # 24 hours
+
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RE_APPID = re.compile(
+    r'href=["\']https?://store\.steampowered\.com/app/(\d+)/', re.IGNORECASE
+)
+_RE_MATCH_NAME = re.compile(
+    r'class=["\']match_name["\'][^>]*>([^<]+)<', re.IGNORECASE
+)
+
+
+def _normalize(s: str) -> str:
+    return _RE_NON_ALNUM.sub(" ", s.lower()).strip()
+
+
+def _similarity(query_norm: str, result_norm: str) -> float:
+    if query_norm == result_norm:
+        return 1.0
+    if query_norm in result_norm or result_norm in query_norm:
+        return 0.8
+    q_words = set(query_norm.split())
+    r_words = set(result_norm.split())
+    if not q_words or not r_words:
+        return 0.0
+    return len(q_words & r_words) / max(len(q_words), len(r_words))
+
+
+async def _steam_find_appid(session, title: str) -> int | None:
+    """Search Steam Store suggest for title, return best-matching App ID."""
+    norm_title = _normalize(title)
+    now = time.monotonic()
+    cached = _APPID_CACHE.get(norm_title)
+    if cached and now - cached[1] < _APPID_CACHE_TTL:
+        return cached[0]
+
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (compatible; media-art-wrapper-ha/3.0; "
+            "+https://github.com/Levtos/Media_Art_Wrapper)"
+        ),
+    }
+    try:
+        async with session.get(
+            _STEAM_SUGGEST_URL,
+            params={"term": title, "f": "games", "cc": "US", "l": "english"},
+            headers=headers,
+            timeout=10,
+        ) as resp:
+            if resp.status != 200:
+                return None
+            html = await resp.text(encoding="utf-8", errors="ignore")
+    except Exception as err:
+        _LOGGER.debug("Steam suggest failed for %r: %s", title, err)
+        return None
+
+    appids = _RE_APPID.findall(html)
+    names = _RE_MATCH_NAME.findall(html)
+    if not appids:
+        return None
+
+    best_appid: int | None = None
+    best_score = -1.0
+    for raw_appid, raw_name in zip(appids, names if names else [""] * len(appids)):
+        score = _similarity(norm_title, _normalize(raw_name))
+        if score > best_score:
+            best_score = score
+            best_appid = int(raw_appid)
+
+    if best_appid is None or best_score < 0.3:
+        return None
+
+    _APPID_CACHE[norm_title] = (best_appid, now)
+    return best_appid
+
+
+class SteamProvider(ArtworkProvider):
+    """Steam Store — no API key required, portrait library art."""
+
+    categories = frozenset({"gaming", "auto"})
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        title = (query.title or "").strip()
+        if not title:
+            return None
+
+        appid = await _steam_find_appid(session, title)
+        if appid is None:
+            return None
+
+        for template in _STEAM_IMAGE_TEMPLATES:
+            url = template.format(appid=appid)
+            try:
+                async with session.get(url, timeout=10) as resp:
+                    if resp.status == 404:
+                        continue
+                    resp.raise_for_status()
+                    ct = resp.headers.get("Content-Type", "image/jpeg")
+                    image = await resp.read()
+            except Exception as err:
+                _LOGGER.debug("Steam image fetch failed (%s): %s", url, err)
+                continue
+
+            if image:
+                return ArtworkResult(
+                    provider_name="steam",
+                    image_url=url,
+                    confidence=0.85,
+                    image=image,
+                    content_type=ct,
+                )
+
+        return None
+
+
+class SteamGridDBProvider(ArtworkProvider):
+    """SteamGridDB — high-quality community game art (API key required)."""
+
+    categories = frozenset({"gaming", "auto"})
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = (api_key or "").strip()
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        title = (query.title or "").strip()
+        if not title:
+            return None
+
+        headers = {"Authorization": f"Bearer {self._api_key}"}
+
+        # Search for the game by title
+        search_url = SGDB_SEARCH_URL.format(term=title)
+        try:
+            async with session.get(search_url, headers=headers, timeout=10) as resp:
+                resp.raise_for_status()
+                data: dict[str, Any] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("SteamGridDB search failed for %r: %s", title, err)
+            return None
+
+        if not isinstance(data, dict) or not data.get("success"):
+            return None
+
+        results: list[dict[str, Any]] = data.get("data") or []
+        if not isinstance(results, list) or not results:
+            return None
+
+        # Find best-matching game by name similarity
+        best_game: dict[str, Any] | None = None
+        best_score = -1.0
+        norm_title = _normalize(title)
+        for game in results:
+            if not isinstance(game, dict):
+                continue
+            gname = _normalize(str(game.get("name") or ""))
+            score = _similarity(norm_title, gname)
+            if score > best_score:
+                best_score = score
+                best_game = game
+
+        if best_game is None or best_score < 0.3:
+            return None
+
+        game_id = best_game.get("id")
+        if not isinstance(game_id, int):
+            return None
+
+        # Determine dimensions for grid filtering
+        is_portrait = query.artwork_height >= query.artwork_width
+        dimensions = "600x900" if is_portrait else "920x430"
+
+        grids_url = SGDB_GRIDS_URL.format(game_id=game_id)
+        try:
+            async with session.get(
+                grids_url,
+                headers=headers,
+                params={"dimensions": dimensions, "limit": "1"},
+                timeout=10,
+            ) as resp:
+                resp.raise_for_status()
+                grids_data: dict[str, Any] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("SteamGridDB grids fetch failed: %s", err)
+            return None
+
+        if not isinstance(grids_data, dict) or not grids_data.get("success"):
+            # Retry without dimension filter
+            try:
+                async with session.get(
+                    grids_url,
+                    headers=headers,
+                    params={"limit": "1"},
+                    timeout=10,
+                ) as resp:
+                    resp.raise_for_status()
+                    grids_data = await resp.json(**_JSON_KW)
+            except Exception:
+                return None
+
+        grids = grids_data.get("data") or []
+        if not isinstance(grids, list) or not grids:
+            return None
+
+        first = grids[0]
+        if not isinstance(first, dict):
+            return None
+
+        url = first.get("url")
+        if not isinstance(url, str) or not url:
+            return None
+
+        try:
+            async with session.get(url, timeout=10) as resp:
+                resp.raise_for_status()
+                ct = resp.headers.get("Content-Type", "image/png")
+                image = await resp.read()
+        except Exception as err:
+            _LOGGER.debug("SteamGridDB image download failed: %s", err)
+            return None
+
+        if not image:
+            return None
+
+        return ArtworkResult(
+            provider_name="steamgriddb",
+            image_url=url,
+            confidence=0.92,
+            image=image,
+            content_type=ct,
+        )

--- a/custom_components/media_art_wrapper/providers/tmdb.py
+++ b/custom_components/media_art_wrapper/providers/tmdb.py
@@ -1,0 +1,92 @@
+"""The Movie Database (TMDb) provider — streaming films and series."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+
+TMDB_SEARCH_URL = "https://api.themoviedb.org/3/search/multi"
+TMDB_IMAGE_BASE = "https://image.tmdb.org/t/p/w500"
+_JSON_KW = {"content_type": None}
+
+
+class TMDbProvider(ArtworkProvider):
+    """TMDb /search/multi — movies and TV series."""
+
+    categories = frozenset({"streaming", "auto"})
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = (api_key or "").strip()
+
+    def is_available(self) -> bool:
+        return bool(self._api_key)
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        title = (query.title or "").strip()
+        if not title:
+            # For episodes try series title as fallback
+            title = (query.series_title or "").strip()
+        if not title:
+            return None
+
+        try:
+            async with session.get(
+                TMDB_SEARCH_URL,
+                params={"api_key": self._api_key, "query": title, "page": 1},
+                timeout=10,
+            ) as resp:
+                resp.raise_for_status()
+                payload: dict[str, Any] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("TMDb search failed for %r: %s", title, err)
+            return None
+
+        results = payload.get("results") if isinstance(payload, dict) else None
+        if not isinstance(results, list) or not results:
+            return None
+
+        # Prefer: exact media_type match for episode content → tv, else movie
+        preferred_type = "tv" if query.content_type in ("episode", "tv_episode") else None
+
+        best: dict[str, Any] | None = None
+        for item in results:
+            if not isinstance(item, dict):
+                continue
+            if preferred_type and item.get("media_type") == preferred_type:
+                best = item
+                break
+        if best is None:
+            # Accept first result regardless of type
+            best = next((r for r in results if isinstance(r, dict) and r.get("poster_path")), None)
+        if best is None:
+            return None
+
+        poster_path = best.get("poster_path")
+        if not isinstance(poster_path, str) or not poster_path:
+            return None
+
+        # Pick image size closest to requested dimensions
+        size = "w500" if max(query.artwork_width, query.artwork_height) <= 600 else "original"
+        url = f"https://image.tmdb.org/t/p/{size}{poster_path}"
+        try:
+            async with session.get(url, timeout=10) as resp:
+                resp.raise_for_status()
+                ct = resp.headers.get("Content-Type", "image/jpeg")
+                image = await resp.read()
+        except Exception as err:
+            _LOGGER.debug("TMDb image fetch failed: %s", err)
+            return None
+
+        if not image:
+            return None
+
+        return ArtworkResult(
+            provider_name="tmdb",
+            image_url=url,
+            confidence=0.9,
+            image=image,
+            content_type=ct,
+        )

--- a/custom_components/media_art_wrapper/providers/tvmaze.py
+++ b/custom_components/media_art_wrapper/providers/tvmaze.py
@@ -1,0 +1,455 @@
+"""TVMaze + EPG + Wikipedia provider — TV channel/show artwork."""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+
+TVMAZE_SEARCH_URL = "https://api.tvmaze.com/search/shows"
+TVMAZE_SCHEDULE_URL = "https://api.tvmaze.com/schedule"
+WIKIPEDIA_API_URL = "https://{lang}.wikipedia.org/w/api.php"
+_COMMONS_API_URL = "https://commons.wikimedia.org/w/api.php"
+
+# ÖRR curated HD channel list page (German public broadcasters)
+_OERR_LIST_PAGE = "Liste der öffentlich-rechtlichen HD-Programme in Europa"
+
+_JSON_KW = {"content_type": None}
+
+# Module-level caches
+_oerr_image_cache: list[str] | None = None
+_schedule_cache: dict[str, list[dict[str, Any]]] = {}
+
+_RE_NON_ALNUM = re.compile(r"[^a-z0-9]+")
+_RE_SPACES = re.compile(r"\s+")
+
+# Filenames containing these words are unlikely to be the *current* logo.
+_LOGO_EXCLUDE = {
+    "karte", "map", "germany", "deutschland",
+    "studio", "gebäude", "building", "headquarters", "sitz", "standort",
+    "portrait", "foto", "photo", "bild", "picture",
+    "alte", "altes", "alter", "alten", "ehemals", "ehemalig", "ehemalige",
+    "former", "historical", "history", "old", "variation", "variante",
+    "varianten", "uebersicht", "übersicht", "sammlung", "collection",
+}
+_LOGO_BOOST = {"logo", "dachmarke", "wortmarke", "signet", "icon", "emblem"}
+
+
+def _clean(s: str) -> str:
+    s = s.strip().lower()
+    s = _RE_NON_ALNUM.sub(" ", s)
+    return _RE_SPACES.sub(" ", s).strip()
+
+
+def _names_overlap(a: str, b: str) -> bool:
+    ca, cb = _clean(a), _clean(b)
+    return bool(ca and cb and (ca in cb or cb in ca))
+
+
+# ---------------------------------------------------------------------------
+# EPG helpers (TVMaze Germany schedule)
+# ---------------------------------------------------------------------------
+
+async def _fetch_schedule(session, date_str: str) -> list[dict[str, Any]]:
+    if date_str in _schedule_cache:
+        return _schedule_cache[date_str]
+
+    try:
+        async with session.get(
+            TVMAZE_SCHEDULE_URL,
+            params={"country": "DE", "date": date_str},
+            timeout=15,
+        ) as resp:
+            resp.raise_for_status()
+            payload = await resp.json(**_JSON_KW)
+    except Exception as err:
+        _LOGGER.debug("TVMaze schedule fetch failed (%s): %s", date_str, err)
+        return []
+
+    if not isinstance(payload, list):
+        return []
+
+    _schedule_cache[date_str] = payload
+    # Evict old entries – keep only today and yesterday
+    for old_key in [k for k in _schedule_cache if k < date_str]:
+        del _schedule_cache[old_key]
+    return payload
+
+
+def _network_name(episode: dict[str, Any]) -> str:
+    show = episode.get("show") or {}
+    network = show.get("network") or {}
+    web_channel = show.get("webChannel") or {}
+    return str(network.get("name") or web_channel.get("name") or "")
+
+
+def _channel_matches(episode: dict[str, Any], channel_tokens: list[str]) -> bool:
+    net = _clean(_network_name(episode))
+    if not net:
+        return False
+    return all(tok in net for tok in channel_tokens if len(tok) >= 2)
+
+
+def _is_airing_now(episode: dict[str, Any], now: datetime) -> bool:
+    airstamp = episode.get("airstamp")
+    runtime = episode.get("runtime") or 30
+    if not airstamp:
+        return False
+    try:
+        start = datetime.fromisoformat(airstamp)
+        if start.tzinfo is None:
+            start = start.replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return False
+    return start <= now <= start + timedelta(minutes=runtime)
+
+
+def _episode_image_url(episode: dict[str, Any]) -> str | None:
+    for source in (episode.get("image"), (episode.get("show") or {}).get("image")):
+        if isinstance(source, dict):
+            url = source.get("original") or source.get("medium")
+            if isinstance(url, str) and url:
+                return url
+    return None
+
+
+async def _epg_get_current_program(
+    session, channel_name: str
+) -> dict[str, Any] | None:
+    """Return metadata for the programme currently airing on channel_name."""
+    channel_tokens = _clean(channel_name).split()
+    if not channel_tokens:
+        return None
+
+    now = datetime.now(tz=timezone.utc)
+    date_str = now.strftime("%Y-%m-%d")
+
+    for fetch_date in (date_str, (now - timedelta(days=1)).strftime("%Y-%m-%d")):
+        schedule = await _fetch_schedule(session, fetch_date)
+        for episode in schedule:
+            if not isinstance(episode, dict):
+                continue
+            if not _channel_matches(episode, channel_tokens):
+                continue
+            if not _is_airing_now(episode, now):
+                continue
+            show = episode.get("show") or {}
+            return {
+                "title": str(episode.get("name") or ""),
+                "show_name": str(show.get("name") or ""),
+                "image_url": _episode_image_url(episode),
+            }
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# TVMaze show search
+# ---------------------------------------------------------------------------
+
+async def _tvmaze_show_image(session, term: str) -> str | None:
+    try:
+        async with session.get(
+            TVMAZE_SEARCH_URL, params={"q": term}, timeout=10
+        ) as resp:
+            resp.raise_for_status()
+            results = await resp.json(**_JSON_KW)
+    except Exception as err:
+        _LOGGER.debug("TVMaze show search failed for %r: %s", term, err)
+        return None
+
+    if not isinstance(results, list) or not results:
+        return None
+
+    best = results[0]
+    if not isinstance(best, dict):
+        return None
+    show = best.get("show")
+    if not isinstance(show, dict):
+        return None
+
+    show_name = str(show.get("name") or "")
+    if not _names_overlap(term, show_name):
+        return None
+
+    image_data = show.get("image")
+    if not isinstance(image_data, dict):
+        return None
+    url = image_data.get("original") or image_data.get("medium")
+    return str(url) if isinstance(url, str) and url else None
+
+
+# ---------------------------------------------------------------------------
+# Wikipedia / Wikimedia Commons logo lookup
+# ---------------------------------------------------------------------------
+
+def _score_image_file(filename: str, channel_tokens: list[str]) -> int:
+    fn = filename.lower()
+    fn = re.sub(r"^(file|datei):", "", fn).strip()
+
+    if any(excl in fn for excl in _LOGO_EXCLUDE):
+        return -1
+
+    score = 0
+    if any(boost in fn for boost in _LOGO_BOOST):
+        score += 3
+    if any(tok in fn for tok in channel_tokens if len(tok) >= 2):
+        score += 2
+    if fn.endswith(".svg"):
+        score += 1
+    return score
+
+
+async def _resolve_commons_url(session, file_title: str, thumb_width: int) -> str | None:
+    params = {
+        "action": "query",
+        "titles": file_title,
+        "prop": "imageinfo",
+        "iiprop": "url",
+        "iiurlwidth": str(thumb_width),
+        "format": "json",
+    }
+    try:
+        async with session.get(_COMMONS_API_URL, params=params, timeout=10) as resp:
+            resp.raise_for_status()
+            payload = await resp.json(**_JSON_KW)
+    except Exception as err:
+        _LOGGER.debug("Commons imageinfo failed for %r: %s", file_title, err)
+        return None
+
+    pages = payload.get("query", {}).get("pages", {}) if isinstance(payload, dict) else {}
+    for page in pages.values():
+        if not isinstance(page, dict):
+            continue
+        for info in page.get("imageinfo") or []:
+            url = info.get("thumburl") or info.get("url")
+            if isinstance(url, str) and url:
+                return url
+    return None
+
+
+async def _fetch_oerr_images(session) -> list[str]:
+    global _oerr_image_cache
+    if _oerr_image_cache is not None:
+        return _oerr_image_cache
+
+    api_url = WIKIPEDIA_API_URL.format(lang="de")
+    try:
+        async with session.get(
+            api_url,
+            params={
+                "action": "query",
+                "titles": _OERR_LIST_PAGE,
+                "prop": "images",
+                "imlimit": "500",
+                "format": "json",
+            },
+            timeout=15,
+        ) as resp:
+            resp.raise_for_status()
+            payload = await resp.json(**_JSON_KW)
+    except Exception as err:
+        _LOGGER.debug("ÖRR list page fetch failed: %s", err)
+        _oerr_image_cache = []
+        return []
+
+    pages = payload.get("query", {}).get("pages", {}) if isinstance(payload, dict) else {}
+    images: list[str] = []
+    for page in pages.values():
+        if not isinstance(page, dict):
+            continue
+        for img in page.get("images") or []:
+            t = img.get("title")
+            if isinstance(t, str) and t:
+                images.append(t)
+
+    _oerr_image_cache = images
+    return images
+
+
+async def _oerr_list_logo(session, channel_name: str, thumb_width: int) -> str | None:
+    images = await _fetch_oerr_images(session)
+    if not images:
+        return None
+
+    channel_tokens = _clean(channel_name).split()
+    best_score = 0
+    best_file: str | None = None
+
+    for img_title in images:
+        fn = img_title.lower()
+        fn = re.sub(r"^(file|datei):", "", fn).strip()
+
+        matched = sum(1 for tok in channel_tokens if len(tok) >= 2 and tok in fn)
+        if matched == 0:
+            continue
+        score = matched * 2
+        if any(boost in fn for boost in _LOGO_BOOST):
+            score += 3
+        if fn.endswith(".svg"):
+            score += 1
+
+        if score > best_score:
+            best_score = score
+            best_file = img_title
+
+    if not best_file:
+        return None
+    return await _resolve_commons_url(session, best_file, thumb_width)
+
+
+async def _wikipedia_logo(session, title: str, thumb_width: int = 600) -> str | None:
+    channel_tokens = _clean(title).split()
+
+    for lang in ("de", "en"):
+        api_url = WIKIPEDIA_API_URL.format(lang=lang)
+        try:
+            async with session.get(
+                api_url,
+                params={
+                    "action": "query",
+                    "titles": title,
+                    "prop": "images",
+                    "imlimit": "30",
+                    "format": "json",
+                    "redirects": 1,
+                },
+                timeout=10,
+            ) as resp:
+                resp.raise_for_status()
+                payload = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("Wikipedia (%s) lookup failed for %r: %s", lang, title, err)
+            continue
+
+        pages = payload.get("query", {}).get("pages", {}) if isinstance(payload, dict) else {}
+        image_titles: list[str] = []
+        for page in pages.values():
+            if not isinstance(page, dict):
+                continue
+            for img in page.get("images") or []:
+                t = img.get("title")
+                if isinstance(t, str) and t:
+                    image_titles.append(t)
+
+        if not image_titles:
+            continue
+
+        best_score = 0
+        best_file: str | None = None
+        for img_title in image_titles:
+            score = _score_image_file(img_title, channel_tokens)
+            if score > best_score:
+                best_score = score
+                best_file = img_title
+
+        if not best_file:
+            continue
+
+        url = await _resolve_commons_url(session, best_file, thumb_width)
+        if url:
+            return url
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Provider class
+# ---------------------------------------------------------------------------
+
+class TVMazeProvider(ArtworkProvider):
+    """TV artwork via EPG + TVMaze show search + Wikipedia channel logos.
+
+    Search order:
+      1. EPG (TVMaze DE schedule) — if title looks like a channel name,
+         find what's currently airing and use that programme's image.
+         If EPG returns a title but no image, use it for subsequent searches.
+      2. TVMaze show search — free, no API key.
+      3. ÖRR HD list page (curated, Europe-wide public broadcasters).
+      4. Generic Wikipedia article logo lookup.
+    """
+
+    categories = frozenset({"tv", "auto"})
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        title = (query.title or "").strip()
+        if not title:
+            return None
+
+        thumb_width = max(100, int(max(query.artwork_width, query.artwork_height)))
+        effective_search = title
+        artwork_url: str | None = None
+        provider_name: str | None = None
+
+        # Strip broadcast-technical suffix for channel matching
+        from .query_builder import _strip_channel
+        stripped_title = _strip_channel(title)
+
+        # 1. EPG lookup -------------------------------------------------------
+        # Only when the title has a broadcast suffix (HD/SD) or no artist
+        # is set — both are strong signals of a channel name rather than a show.
+        is_channel_name = stripped_title != title or not (query.artist or "").strip()
+        if is_channel_name and title:
+            epg = await _epg_get_current_program(session, stripped_title or title)
+            if epg:
+                if epg.get("image_url"):
+                    artwork_url = epg["image_url"]
+                    provider_name = "tv_epg"
+                    _LOGGER.debug(
+                        "EPG hit: channel=%r → programme=%r image=%r",
+                        title, epg.get("show_name") or epg.get("title"), artwork_url,
+                    )
+                elif epg.get("show_name") or epg.get("title"):
+                    effective_search = epg.get("show_name") or epg.get("title") or title
+                    _LOGGER.debug(
+                        "EPG title redirect: channel=%r → search=%r", title, effective_search
+                    )
+
+        # 2. TVMaze show search -----------------------------------------------
+        if not artwork_url:
+            artwork_url = await _tvmaze_show_image(session, effective_search)
+            if artwork_url:
+                provider_name = "tv_tvmaze"
+
+        # 3. Channel logo lookup ---------------------------------------------
+        if not artwork_url and title:
+            for candidate in dict.fromkeys(filter(None, [stripped_title, title])):
+                artwork_url = await _oerr_list_logo(session, candidate, thumb_width)
+                if artwork_url:
+                    provider_name = "tv_wikipedia_oerr"
+                    break
+
+            if not artwork_url:
+                for candidate in dict.fromkeys(filter(None, [stripped_title, title])):
+                    artwork_url = await _wikipedia_logo(session, candidate, thumb_width=thumb_width)
+                    if artwork_url:
+                        provider_name = "tv_wikipedia"
+                        break
+
+        if not artwork_url or not provider_name:
+            return None
+
+        # Download the resolved image
+        try:
+            async with session.get(artwork_url, timeout=10) as resp:
+                resp.raise_for_status()
+                ct = resp.headers.get("Content-Type", "image/jpeg")
+                image = await resp.read()
+        except Exception as err:
+            _LOGGER.debug("TVMaze provider image download failed (%s): %s", artwork_url, err)
+            return None
+
+        if not image:
+            return None
+
+        return ArtworkResult(
+            provider_name=provider_name,
+            image_url=artwork_url,
+            confidence=0.80,
+            image=image,
+            content_type=ct,
+        )

--- a/custom_components/media_art_wrapper/strings.json
+++ b/custom_components/media_art_wrapper/strings.json
@@ -2,20 +2,56 @@
   "config": {
     "step": {
       "user": {
-        "title": "Media Art Wrapper",
-        "description": "Select a media player. Cover art will be resolved from media_artist + media_title.",
+        "title": "Media Art Wrapper — Player",
+        "description": "Select the media player to wrap and choose how its content should be categorised.",
         "data": {
           "source_entity_id": "Media player",
-          "provider_1": "Priority 1 (highest)",
-          "provider_2": "Priority 2",
-          "provider_3": "Priority 3",
-          "provider_4": "Priority 4",
-          "provider_5": "Priority 5 (lowest)",
-          "artwork_preset": "Artwork size",
+          "display_name": "Display name",
+          "category": "Content category"
+        },
+        "data_description": {
+          "source_entity_id": "The media player entity whose artwork will be resolved.",
+          "display_name": "Friendly name shown in Home Assistant. Leave blank to use the player name.",
+          "category": "Determines which artwork providers are used. Choose Auto to try all providers."
+        }
+      },
+      "artwork": {
+        "title": "Media Art Wrapper — Artwork",
+        "description": "Configure the artwork image dimensions, fallback behaviour, and optional API keys.",
+        "data": {
+          "ratio": "Aspect ratio",
           "artwork_width": "Custom width (px)",
           "artwork_height": "Custom height (px)",
+          "fallback_mode": "Fallback when no artwork is found",
+          "fallback_custom_url": "Custom fallback image URL",
+          "tmdb_api_key": "TMDb API key (streaming)",
+          "igdb_client_id": "IGDB Client ID (gaming)",
+          "igdb_client_secret": "IGDB Client Secret (gaming)",
+          "steamgriddb_api_key": "SteamGridDB API key (optional, gaming)",
+          "fanart_api_key": "Fanart.tv API key (optional, TV)",
+          "xmltv_url": "XMLTV EPG feed URL (optional, TV)"
+        },
+        "data_description": {
+          "ratio": "Preset dimensions for the artwork image. Choose Custom to enter exact pixel values.",
+          "artwork_width": "Only used when Custom is selected above.",
+          "artwork_height": "Only used when Custom is selected above.",
+          "fallback_mode": "What to show when no artwork can be found for the current track.",
+          "fallback_custom_url": "Full URL to an image shown when no artwork is found. Only used when Custom URL is selected above.",
+          "tmdb_api_key": "Required for The Movie Database streaming artwork. Leave blank to skip.",
+          "igdb_client_id": "Twitch developer app Client ID, required for IGDB game cover art.",
+          "igdb_client_secret": "Twitch developer app Client Secret, required for IGDB game cover art.",
+          "steamgriddb_api_key": "Optional. Enables high-quality community game art from SteamGridDB. Steam Store artwork works without a key.",
+          "fanart_api_key": "Optional. Enables TV show logos and posters from Fanart.tv.",
+          "xmltv_url": "Optional XMLTV EPG feed for advanced channel programme matching. Not yet implemented (planned for v3.1)."
+        }
+      },
+      "combined": {
+        "title": "Media Art Wrapper — Combined Player",
+        "description": "Optionally create a virtual combined player that aggregates multiple media players.",
+        "data": {
           "create_combined": "Create combined player",
           "combined_name": "Combined player name",
+          "auto_priority": "Auto-sort sources by category priority",
           "combined_source_1": "Source 1 (highest priority)",
           "combined_source_2": "Source 2",
           "combined_source_3": "Source 3",
@@ -27,14 +63,11 @@
           "combined_audio_sources": "Audio control targets (optional)"
         },
         "data_description": {
-          "provider_1": "The first provider that returns a result is used. Set lower slots to — to disable them.",
-          "artwork_preset": "Choose a common preset or select 'Custom …' to enter exact pixel dimensions below.",
-          "artwork_width": "Only used when 'Custom …' is selected above.",
-          "artwork_height": "Only used when 'Custom …' is selected above.",
-          "create_combined": "When enabled, creates media_player.<name> and image.<name>_cover aggregating the sources below.",
-          "combined_name": "Used as entity ID: media_player.<name> and image.<name>_cover. Use lowercase with underscores, e.g. alle_mediengeraete.",
-          "combined_source_1": "Priority ordered: PLAYING > PAUSED/IDLE > ON. Within the same state, lower slot number wins.",
-          "combined_audio_sources": "Optional. If set, volume/shuffle/repeat and control commands are routed to the active audio source instead of the display source."
+          "create_combined": "When enabled, creates a virtual media_player entity and a cover image entity aggregating the sources below.",
+          "combined_name": "Used to name the entities: media_player.NAME and image.NAME_cover. Use lowercase letters and underscores only.",
+          "auto_priority": "When enabled, sources are automatically reordered by category: Gaming first, then Streaming, TV, Music, Auto.",
+          "combined_source_1": "Priority ordered: PLAYING or BUFFERING beats PAUSED or IDLE, which beats ON. Lower slot number wins within the same tier.",
+          "combined_audio_sources": "Optional. Volume, shuffle, repeat and playback commands are routed to the active audio source instead of the display source."
         }
       }
     },
@@ -45,17 +78,54 @@
   "options": {
     "step": {
       "init": {
+        "title": "Media Art Wrapper — Player",
+        "description": "Update the category and display name for this media player.",
         "data": {
-          "provider_1": "Priority 1 (highest)",
-          "provider_2": "Priority 2",
-          "provider_3": "Priority 3",
-          "provider_4": "Priority 4",
-          "provider_5": "Priority 5 (lowest)",
-          "artwork_preset": "Artwork size",
+          "display_name": "Display name",
+          "category": "Content category"
+        },
+        "data_description": {
+          "display_name": "Friendly name shown in Home Assistant.",
+          "category": "Determines which artwork providers are used. Choose Auto to try all providers."
+        }
+      },
+      "artwork": {
+        "title": "Media Art Wrapper — Artwork",
+        "description": "Configure the artwork image dimensions, fallback behaviour, and optional API keys.",
+        "data": {
+          "ratio": "Aspect ratio",
           "artwork_width": "Custom width (px)",
           "artwork_height": "Custom height (px)",
+          "fallback_mode": "Fallback when no artwork is found",
+          "fallback_custom_url": "Custom fallback image URL",
+          "tmdb_api_key": "TMDb API key (streaming)",
+          "igdb_client_id": "IGDB Client ID (gaming)",
+          "igdb_client_secret": "IGDB Client Secret (gaming)",
+          "steamgriddb_api_key": "SteamGridDB API key (optional, gaming)",
+          "fanart_api_key": "Fanart.tv API key (optional, TV)",
+          "xmltv_url": "XMLTV EPG feed URL (optional, TV)"
+        },
+        "data_description": {
+          "ratio": "Preset dimensions for the artwork image. Choose Custom to enter exact pixel values.",
+          "artwork_width": "Only used when Custom is selected above.",
+          "artwork_height": "Only used when Custom is selected above.",
+          "fallback_mode": "What to show when no artwork can be found for the current track.",
+          "fallback_custom_url": "Full URL to an image shown when no artwork is found. Only used when Custom URL is selected above.",
+          "tmdb_api_key": "Required for The Movie Database streaming artwork. Leave blank to skip.",
+          "igdb_client_id": "Twitch developer app Client ID, required for IGDB game cover art.",
+          "igdb_client_secret": "Twitch developer app Client Secret, required for IGDB game cover art.",
+          "steamgriddb_api_key": "Optional. Enables high-quality community game art from SteamGridDB. Steam Store artwork works without a key.",
+          "fanart_api_key": "Optional. Enables TV show logos and posters from Fanart.tv.",
+          "xmltv_url": "Optional XMLTV EPG feed for advanced channel programme matching. Not yet implemented (planned for v3.1)."
+        }
+      },
+      "combined": {
+        "title": "Media Art Wrapper — Combined Player",
+        "description": "Optionally create a virtual combined player that aggregates multiple media players.",
+        "data": {
           "create_combined": "Create combined player",
           "combined_name": "Combined player name",
+          "auto_priority": "Auto-sort sources by category priority",
           "combined_source_1": "Source 1 (highest priority)",
           "combined_source_2": "Source 2",
           "combined_source_3": "Source 3",
@@ -67,14 +137,11 @@
           "combined_audio_sources": "Audio control targets (optional)"
         },
         "data_description": {
-          "provider_1": "The first provider that returns a result is used. Set lower slots to — to disable them.",
-          "artwork_preset": "Choose a common preset or select 'Custom …' to enter exact pixel dimensions below.",
-          "artwork_width": "Only used when 'Custom …' is selected above.",
-          "artwork_height": "Only used when 'Custom …' is selected above.",
-          "create_combined": "When enabled, creates media_player.<name> and image.<name>_cover aggregating the sources below.",
-          "combined_name": "Used as entity ID: media_player.<name> and image.<name>_cover. Use lowercase with underscores, e.g. alle_mediengeraete.",
-          "combined_source_1": "Priority ordered: PLAYING > PAUSED/IDLE > ON. Within the same state, lower slot number wins.",
-          "combined_audio_sources": "Optional. If set, volume/shuffle/repeat and control commands are routed to the active audio source instead of the display source."
+          "create_combined": "When enabled, creates a virtual media_player entity and a cover image entity aggregating the sources below.",
+          "combined_name": "Used to name the entities: media_player.NAME and image.NAME_cover. Use lowercase letters and underscores only.",
+          "auto_priority": "When enabled, sources are automatically reordered by category: Gaming first, then Streaming, TV, Music, Auto.",
+          "combined_source_1": "Priority ordered: PLAYING or BUFFERING beats PAUSED or IDLE, which beats ON. Lower slot number wins within the same tier.",
+          "combined_audio_sources": "Optional. Volume, shuffle, repeat and playback commands are routed to the active audio source instead of the display source."
         }
       }
     }

--- a/custom_components/media_art_wrapper/translations/de.json
+++ b/custom_components/media_art_wrapper/translations/de.json
@@ -2,20 +2,56 @@
   "config": {
     "step": {
       "user": {
-        "title": "Media Art Wrapper",
-        "description": "Wähle einen Media Player aus. Cover Art wird anhand von media_artist + media_title ermittelt.",
+        "title": "Media Art Wrapper — Player",
+        "description": "Wähle einen Media Player aus und lege fest, wie dessen Inhalte kategorisiert werden sollen.",
         "data": {
           "source_entity_id": "Media Player",
-          "provider_1": "Priorität 1 (höchste)",
-          "provider_2": "Priorität 2",
-          "provider_3": "Priorität 3",
-          "provider_4": "Priorität 4",
-          "provider_5": "Priorität 5 (niedrigste)",
-          "artwork_preset": "Artwork-Größe",
+          "display_name": "Anzeigename",
+          "category": "Inhaltskategorie"
+        },
+        "data_description": {
+          "source_entity_id": "Die Media-Player-Entity, deren Artwork ermittelt werden soll.",
+          "display_name": "In Home Assistant angezeigter Name. Leer lassen, um den Playernamen zu verwenden.",
+          "category": "Bestimmt, welche Artwork-Provider verwendet werden. Auto probiert alle Provider."
+        }
+      },
+      "artwork": {
+        "title": "Media Art Wrapper — Artwork",
+        "description": "Konfiguriere Bildabmessungen, Fallback-Verhalten und optionale API-Schlüssel.",
+        "data": {
+          "ratio": "Seitenverhältnis",
           "artwork_width": "Benutzerdefinierte Breite (px)",
           "artwork_height": "Benutzerdefinierte Höhe (px)",
+          "fallback_mode": "Fallback wenn kein Artwork gefunden wird",
+          "fallback_custom_url": "URL für benutzerdefiniertes Fallback-Bild",
+          "tmdb_api_key": "TMDb API-Schlüssel (Streaming)",
+          "igdb_client_id": "IGDB Client ID (Gaming)",
+          "igdb_client_secret": "IGDB Client Secret (Gaming)",
+          "steamgriddb_api_key": "SteamGridDB API-Schlüssel (optional, Gaming)",
+          "fanart_api_key": "Fanart.tv API-Schlüssel (optional, TV)",
+          "xmltv_url": "XMLTV EPG-Feed URL (optional, TV)"
+        },
+        "data_description": {
+          "ratio": "Voreingestellte Abmessungen für das Artwork-Bild. Custom für eigene Pixelwerte wählen.",
+          "artwork_width": "Nur aktiv wenn oben Custom gewählt ist.",
+          "artwork_height": "Nur aktiv wenn oben Custom gewählt ist.",
+          "fallback_mode": "Was angezeigt wird, wenn kein Artwork für den aktuellen Titel gefunden wird.",
+          "fallback_custom_url": "Vollständige URL eines Bildes, das als Fallback angezeigt wird. Nur aktiv bei Custom URL.",
+          "tmdb_api_key": "Erforderlich für Streaming-Artwork von The Movie Database. Leer lassen zum Überspringen.",
+          "igdb_client_id": "Twitch-Developer-App Client ID, erforderlich für IGDB-Spiele-Cover.",
+          "igdb_client_secret": "Twitch-Developer-App Client Secret, erforderlich für IGDB-Spiele-Cover.",
+          "steamgriddb_api_key": "Optional. Ermöglicht hochwertige Community-Spielegrafiken von SteamGridDB. Steam-Store-Artwork funktioniert ohne Schlüssel.",
+          "fanart_api_key": "Optional. Aktiviert TV-Logos und Poster von Fanart.tv.",
+          "xmltv_url": "Optionaler XMLTV-EPG-Feed für erweitertes Kanal-Programm-Matching. Noch nicht implementiert (geplant für v3.1)."
+        }
+      },
+      "combined": {
+        "title": "Media Art Wrapper — Kombinierter Player",
+        "description": "Optional einen virtuellen kombinierten Player erstellen, der mehrere Media Player zusammenfasst.",
+        "data": {
           "create_combined": "Kombinierten Player erstellen",
           "combined_name": "Name des kombinierten Players",
+          "auto_priority": "Quellen automatisch nach Kategorie-Priorität sortieren",
           "combined_source_1": "Quelle 1 (höchste Priorität)",
           "combined_source_2": "Quelle 2",
           "combined_source_3": "Quelle 3",
@@ -27,14 +63,11 @@
           "combined_audio_sources": "Audio-Steuerziele (optional)"
         },
         "data_description": {
-          "provider_1": "Der erste Provider, der ein Ergebnis liefert, wird verwendet. Nicht benötigte Slots auf — setzen.",
-          "artwork_preset": "Häufige Größe auswählen oder 'Benutzerdefiniert …' für eigene Pixelangaben.",
-          "artwork_width": "Nur aktiv wenn oben 'Benutzerdefiniert …' gewählt ist.",
-          "artwork_height": "Nur aktiv wenn oben 'Benutzerdefiniert …' gewählt ist.",
-          "create_combined": "Wenn aktiviert, werden media_player.<name> und image.<name>_cover erstellt, die die unten angegebenen Quellen zusammenfassen.",
-          "combined_name": "Wird als Entity-ID verwendet: media_player.<name> und image.<name>_cover. Kleinbuchstaben mit Unterstrichen, z. B. alle_mediengeraete.",
-          "combined_source_1": "Prioritätsreihenfolge: PLAYING > PAUSED/IDLE > ON. Bei gleichem Zustand gewinnt die niedrigere Slotnummer.",
-          "combined_audio_sources": "Optional. Falls gesetzt, werden Lautstärke, Shuffle, Repeat und Steuerbefehle an die aktive Audio-Quelle statt an die Anzeigequelle weitergeleitet."
+          "create_combined": "Wenn aktiviert, werden eine virtuelle media_player-Entity und eine Cover-Bild-Entity erstellt, die die unten angegebenen Quellen zusammenfassen.",
+          "combined_name": "Wird für die Entity-Namen verwendet: media_player.NAME und image.NAME_cover. Nur Kleinbuchstaben und Unterstriche.",
+          "auto_priority": "Wenn aktiviert, werden Quellen automatisch nach Kategorie sortiert: Gaming zuerst, dann Streaming, TV, Musik, Auto.",
+          "combined_source_1": "Prioritätsreihenfolge: PLAYING oder BUFFERING schlägt PAUSED oder IDLE, was ON schlägt. Bei gleichem Status gewinnt die niedrigere Slotnummer.",
+          "combined_audio_sources": "Optional. Lautstärke, Shuffle, Repeat und Wiedergabebefehle werden an die aktive Audio-Quelle statt an die Anzeigequelle weitergeleitet."
         }
       }
     },
@@ -45,17 +78,54 @@
   "options": {
     "step": {
       "init": {
+        "title": "Media Art Wrapper — Player",
+        "description": "Kategorie und Anzeigename für diesen Media Player aktualisieren.",
         "data": {
-          "provider_1": "Priorität 1 (höchste)",
-          "provider_2": "Priorität 2",
-          "provider_3": "Priorität 3",
-          "provider_4": "Priorität 4",
-          "provider_5": "Priorität 5 (niedrigste)",
-          "artwork_preset": "Artwork-Größe",
+          "display_name": "Anzeigename",
+          "category": "Inhaltskategorie"
+        },
+        "data_description": {
+          "display_name": "In Home Assistant angezeigter Name.",
+          "category": "Bestimmt, welche Artwork-Provider verwendet werden. Auto probiert alle Provider."
+        }
+      },
+      "artwork": {
+        "title": "Media Art Wrapper — Artwork",
+        "description": "Konfiguriere Bildabmessungen, Fallback-Verhalten und optionale API-Schlüssel.",
+        "data": {
+          "ratio": "Seitenverhältnis",
           "artwork_width": "Benutzerdefinierte Breite (px)",
           "artwork_height": "Benutzerdefinierte Höhe (px)",
+          "fallback_mode": "Fallback wenn kein Artwork gefunden wird",
+          "fallback_custom_url": "URL für benutzerdefiniertes Fallback-Bild",
+          "tmdb_api_key": "TMDb API-Schlüssel (Streaming)",
+          "igdb_client_id": "IGDB Client ID (Gaming)",
+          "igdb_client_secret": "IGDB Client Secret (Gaming)",
+          "steamgriddb_api_key": "SteamGridDB API-Schlüssel (optional, Gaming)",
+          "fanart_api_key": "Fanart.tv API-Schlüssel (optional, TV)",
+          "xmltv_url": "XMLTV EPG-Feed URL (optional, TV)"
+        },
+        "data_description": {
+          "ratio": "Voreingestellte Abmessungen für das Artwork-Bild. Custom für eigene Pixelwerte wählen.",
+          "artwork_width": "Nur aktiv wenn oben Custom gewählt ist.",
+          "artwork_height": "Nur aktiv wenn oben Custom gewählt ist.",
+          "fallback_mode": "Was angezeigt wird, wenn kein Artwork für den aktuellen Titel gefunden wird.",
+          "fallback_custom_url": "Vollständige URL eines Bildes, das als Fallback angezeigt wird. Nur aktiv bei Custom URL.",
+          "tmdb_api_key": "Erforderlich für Streaming-Artwork von The Movie Database. Leer lassen zum Überspringen.",
+          "igdb_client_id": "Twitch-Developer-App Client ID, erforderlich für IGDB-Spiele-Cover.",
+          "igdb_client_secret": "Twitch-Developer-App Client Secret, erforderlich für IGDB-Spiele-Cover.",
+          "steamgriddb_api_key": "Optional. Ermöglicht hochwertige Community-Spielegrafiken von SteamGridDB. Steam-Store-Artwork funktioniert ohne Schlüssel.",
+          "fanart_api_key": "Optional. Aktiviert TV-Logos und Poster von Fanart.tv.",
+          "xmltv_url": "Optionaler XMLTV-EPG-Feed für erweitertes Kanal-Programm-Matching. Noch nicht implementiert (geplant für v3.1)."
+        }
+      },
+      "combined": {
+        "title": "Media Art Wrapper — Kombinierter Player",
+        "description": "Optional einen virtuellen kombinierten Player erstellen, der mehrere Media Player zusammenfasst.",
+        "data": {
           "create_combined": "Kombinierten Player erstellen",
           "combined_name": "Name des kombinierten Players",
+          "auto_priority": "Quellen automatisch nach Kategorie-Priorität sortieren",
           "combined_source_1": "Quelle 1 (höchste Priorität)",
           "combined_source_2": "Quelle 2",
           "combined_source_3": "Quelle 3",
@@ -67,14 +137,11 @@
           "combined_audio_sources": "Audio-Steuerziele (optional)"
         },
         "data_description": {
-          "provider_1": "Der erste Provider, der ein Ergebnis liefert, wird verwendet. Nicht benötigte Slots auf — setzen.",
-          "artwork_preset": "Häufige Größe auswählen oder 'Benutzerdefiniert …' für eigene Pixelangaben.",
-          "artwork_width": "Nur aktiv wenn oben 'Benutzerdefiniert …' gewählt ist.",
-          "artwork_height": "Nur aktiv wenn oben 'Benutzerdefiniert …' gewählt ist.",
-          "create_combined": "Wenn aktiviert, werden media_player.<name> und image.<name>_cover erstellt, die die unten angegebenen Quellen zusammenfassen.",
-          "combined_name": "Wird als Entity-ID verwendet: media_player.<name> und image.<name>_cover. Kleinbuchstaben mit Unterstrichen, z. B. alle_mediengeraete.",
-          "combined_source_1": "Prioritätsreihenfolge: PLAYING > PAUSED/IDLE > ON. Bei gleichem Zustand gewinnt die niedrigere Slotnummer.",
-          "combined_audio_sources": "Optional. Falls gesetzt, werden Lautstärke, Shuffle, Repeat und Steuerbefehle an die aktive Audio-Quelle statt an die Anzeigequelle weitergeleitet."
+          "create_combined": "Wenn aktiviert, werden eine virtuelle media_player-Entity und eine Cover-Bild-Entity erstellt, die die unten angegebenen Quellen zusammenfassen.",
+          "combined_name": "Wird für die Entity-Namen verwendet: media_player.NAME und image.NAME_cover. Nur Kleinbuchstaben und Unterstriche.",
+          "auto_priority": "Wenn aktiviert, werden Quellen automatisch nach Kategorie sortiert: Gaming zuerst, dann Streaming, TV, Musik, Auto.",
+          "combined_source_1": "Prioritätsreihenfolge: PLAYING oder BUFFERING schlägt PAUSED oder IDLE, was ON schlägt. Bei gleichem Status gewinnt die niedrigere Slotnummer.",
+          "combined_audio_sources": "Optional. Lautstärke, Shuffle, Repeat und Wiedergabebefehle werden an die aktive Audio-Quelle statt an die Anzeigequelle weitergeleitet."
         }
       }
     }

--- a/custom_components/media_art_wrapper/translations/en.json
+++ b/custom_components/media_art_wrapper/translations/en.json
@@ -2,20 +2,56 @@
   "config": {
     "step": {
       "user": {
-        "title": "Media Art Wrapper",
-        "description": "Select a media player. Cover art will be resolved from media_artist + media_title.",
+        "title": "Media Art Wrapper — Player",
+        "description": "Select the media player to wrap and choose how its content should be categorised.",
         "data": {
           "source_entity_id": "Media player",
-          "provider_1": "Priority 1 (highest)",
-          "provider_2": "Priority 2",
-          "provider_3": "Priority 3",
-          "provider_4": "Priority 4",
-          "provider_5": "Priority 5 (lowest)",
-          "artwork_preset": "Artwork size",
+          "display_name": "Display name",
+          "category": "Content category"
+        },
+        "data_description": {
+          "source_entity_id": "The media player entity whose artwork will be resolved.",
+          "display_name": "Friendly name shown in Home Assistant. Leave blank to use the player name.",
+          "category": "Determines which artwork providers are used. Choose Auto to try all providers."
+        }
+      },
+      "artwork": {
+        "title": "Media Art Wrapper — Artwork",
+        "description": "Configure the artwork image dimensions, fallback behaviour, and optional API keys.",
+        "data": {
+          "ratio": "Aspect ratio",
           "artwork_width": "Custom width (px)",
           "artwork_height": "Custom height (px)",
+          "fallback_mode": "Fallback when no artwork is found",
+          "fallback_custom_url": "Custom fallback image URL",
+          "tmdb_api_key": "TMDb API key (streaming)",
+          "igdb_client_id": "IGDB Client ID (gaming)",
+          "igdb_client_secret": "IGDB Client Secret (gaming)",
+          "steamgriddb_api_key": "SteamGridDB API key (optional, gaming)",
+          "fanart_api_key": "Fanart.tv API key (optional, TV)",
+          "xmltv_url": "XMLTV EPG feed URL (optional, TV)"
+        },
+        "data_description": {
+          "ratio": "Preset dimensions for the artwork image. Choose Custom to enter exact pixel values.",
+          "artwork_width": "Only used when Custom is selected above.",
+          "artwork_height": "Only used when Custom is selected above.",
+          "fallback_mode": "What to show when no artwork can be found for the current track.",
+          "fallback_custom_url": "Full URL to an image shown when no artwork is found. Only used when Custom URL is selected above.",
+          "tmdb_api_key": "Required for The Movie Database streaming artwork. Leave blank to skip.",
+          "igdb_client_id": "Twitch developer app Client ID, required for IGDB game cover art.",
+          "igdb_client_secret": "Twitch developer app Client Secret, required for IGDB game cover art.",
+          "steamgriddb_api_key": "Optional. Enables high-quality community game art from SteamGridDB. Steam Store artwork works without a key.",
+          "fanart_api_key": "Optional. Enables TV show logos and posters from Fanart.tv.",
+          "xmltv_url": "Optional XMLTV EPG feed for advanced channel programme matching. Not yet implemented (planned for v3.1)."
+        }
+      },
+      "combined": {
+        "title": "Media Art Wrapper — Combined Player",
+        "description": "Optionally create a virtual combined player that aggregates multiple media players.",
+        "data": {
           "create_combined": "Create combined player",
           "combined_name": "Combined player name",
+          "auto_priority": "Auto-sort sources by category priority",
           "combined_source_1": "Source 1 (highest priority)",
           "combined_source_2": "Source 2",
           "combined_source_3": "Source 3",
@@ -27,14 +63,11 @@
           "combined_audio_sources": "Audio control targets (optional)"
         },
         "data_description": {
-          "provider_1": "The first provider that returns a result is used. Set lower slots to — to disable them.",
-          "artwork_preset": "Choose a common preset or select 'Custom …' to enter exact pixel dimensions below.",
-          "artwork_width": "Only used when 'Custom …' is selected above.",
-          "artwork_height": "Only used when 'Custom …' is selected above.",
-          "create_combined": "When enabled, creates media_player.<name> and image.<name>_cover aggregating the sources below.",
-          "combined_name": "Used as entity ID: media_player.<name> and image.<name>_cover. Use lowercase with underscores, e.g. alle_mediengeraete.",
-          "combined_source_1": "Priority ordered: PLAYING > PAUSED/IDLE > ON. Within the same state, lower slot number wins.",
-          "combined_audio_sources": "Optional. If set, volume/shuffle/repeat and control commands are routed to the active audio source instead of the display source."
+          "create_combined": "When enabled, creates a virtual media_player entity and a cover image entity aggregating the sources below.",
+          "combined_name": "Used to name the entities: media_player.NAME and image.NAME_cover. Use lowercase letters and underscores only.",
+          "auto_priority": "When enabled, sources are automatically reordered by category: Gaming first, then Streaming, TV, Music, Auto.",
+          "combined_source_1": "Priority ordered: PLAYING or BUFFERING beats PAUSED or IDLE, which beats ON. Lower slot number wins within the same tier.",
+          "combined_audio_sources": "Optional. Volume, shuffle, repeat and playback commands are routed to the active audio source instead of the display source."
         }
       }
     },
@@ -45,17 +78,54 @@
   "options": {
     "step": {
       "init": {
+        "title": "Media Art Wrapper — Player",
+        "description": "Update the category and display name for this media player.",
         "data": {
-          "provider_1": "Priority 1 (highest)",
-          "provider_2": "Priority 2",
-          "provider_3": "Priority 3",
-          "provider_4": "Priority 4",
-          "provider_5": "Priority 5 (lowest)",
-          "artwork_preset": "Artwork size",
+          "display_name": "Display name",
+          "category": "Content category"
+        },
+        "data_description": {
+          "display_name": "Friendly name shown in Home Assistant.",
+          "category": "Determines which artwork providers are used. Choose Auto to try all providers."
+        }
+      },
+      "artwork": {
+        "title": "Media Art Wrapper — Artwork",
+        "description": "Configure the artwork image dimensions, fallback behaviour, and optional API keys.",
+        "data": {
+          "ratio": "Aspect ratio",
           "artwork_width": "Custom width (px)",
           "artwork_height": "Custom height (px)",
+          "fallback_mode": "Fallback when no artwork is found",
+          "fallback_custom_url": "Custom fallback image URL",
+          "tmdb_api_key": "TMDb API key (streaming)",
+          "igdb_client_id": "IGDB Client ID (gaming)",
+          "igdb_client_secret": "IGDB Client Secret (gaming)",
+          "steamgriddb_api_key": "SteamGridDB API key (optional, gaming)",
+          "fanart_api_key": "Fanart.tv API key (optional, TV)",
+          "xmltv_url": "XMLTV EPG feed URL (optional, TV)"
+        },
+        "data_description": {
+          "ratio": "Preset dimensions for the artwork image. Choose Custom to enter exact pixel values.",
+          "artwork_width": "Only used when Custom is selected above.",
+          "artwork_height": "Only used when Custom is selected above.",
+          "fallback_mode": "What to show when no artwork can be found for the current track.",
+          "fallback_custom_url": "Full URL to an image shown when no artwork is found. Only used when Custom URL is selected above.",
+          "tmdb_api_key": "Required for The Movie Database streaming artwork. Leave blank to skip.",
+          "igdb_client_id": "Twitch developer app Client ID, required for IGDB game cover art.",
+          "igdb_client_secret": "Twitch developer app Client Secret, required for IGDB game cover art.",
+          "steamgriddb_api_key": "Optional. Enables high-quality community game art from SteamGridDB. Steam Store artwork works without a key.",
+          "fanart_api_key": "Optional. Enables TV show logos and posters from Fanart.tv.",
+          "xmltv_url": "Optional XMLTV EPG feed for advanced channel programme matching. Not yet implemented (planned for v3.1)."
+        }
+      },
+      "combined": {
+        "title": "Media Art Wrapper — Combined Player",
+        "description": "Optionally create a virtual combined player that aggregates multiple media players.",
+        "data": {
           "create_combined": "Create combined player",
           "combined_name": "Combined player name",
+          "auto_priority": "Auto-sort sources by category priority",
           "combined_source_1": "Source 1 (highest priority)",
           "combined_source_2": "Source 2",
           "combined_source_3": "Source 3",
@@ -67,14 +137,11 @@
           "combined_audio_sources": "Audio control targets (optional)"
         },
         "data_description": {
-          "provider_1": "The first provider that returns a result is used. Set lower slots to — to disable them.",
-          "artwork_preset": "Choose a common preset or select 'Custom …' to enter exact pixel dimensions below.",
-          "artwork_width": "Only used when 'Custom …' is selected above.",
-          "artwork_height": "Only used when 'Custom …' is selected above.",
-          "create_combined": "When enabled, creates media_player.<name> and image.<name>_cover aggregating the sources below.",
-          "combined_name": "Used as entity ID: media_player.<name> and image.<name>_cover. Use lowercase with underscores, e.g. alle_mediengeraete.",
-          "combined_source_1": "Priority ordered: PLAYING > PAUSED/IDLE > ON. Within the same state, lower slot number wins.",
-          "combined_audio_sources": "Optional. If set, volume/shuffle/repeat and control commands are routed to the active audio source instead of the display source."
+          "create_combined": "When enabled, creates a virtual media_player entity and a cover image entity aggregating the sources below.",
+          "combined_name": "Used to name the entities: media_player.NAME and image.NAME_cover. Use lowercase letters and underscores only.",
+          "auto_priority": "When enabled, sources are automatically reordered by category: Gaming first, then Streaming, TV, Music, Auto.",
+          "combined_source_1": "Priority ordered: PLAYING or BUFFERING beats PAUSED or IDLE, which beats ON. Lower slot number wins within the same tier.",
+          "combined_audio_sources": "Optional. Volume, shuffle, repeat and playback commands are routed to the active audio source instead of the display source."
         }
       }
     }


### PR DESCRIPTION
…llbacks

- providers/ subpackage: ArtworkProvider ABC, ArtworkQuery/Result dataclasses, query_builder (per-category transforms), ITunesProvider, MusicBrainzProvider, TMDbProvider, IGDBProvider (Twitch OAuth2), SteamGridDBProvider + SteamProvider, TVMazeProvider (EPG + Wikipedia logos), FanartTvProvider, EPGProvider stub
- config_flow: 3-step UI (Player → Artwork → Combined) with category-specific API key fields; OptionsFlow mirrors the same steps
- __init__: coordinator uses new providers/ pipeline; v1→v2→v3 migration
- image.py: smart fallback system (placeholder / service_logo / custom_url)
- helpers.py: app_name → service logo PNG mapping table
- media_player.py: auto-priority sorting of combined sources by category
- const.py: full v3 constants (categories, ratio, fallback, API keys)
- manifest.json: version 3.0.0
- translations: 3-step labels in en.json / de.json, fixed UNCLOSED_TAG bugs (angle-bracket descriptions replaced with plain text)

https://claude.ai/code/session_01Xcf5HLYSnirZZSuGvQEbDG