### PR TITLE
Improve combined player configuration and validation

### DIFF
--- a/custom_components/media_art_wrapper/config_flow.py
+++ b/custom_components/media_art_wrapper/config_flow.py
@@ -157,7 +157,7 @@ def _step1_schema(source_entity_id: str | None = None, display_name: str = "", c
         )
         if entity_kind != ENTITY_KIND_COMBINED_ONLY:
             kw: dict[str, Any] = {"default": source_entity_id} if source_entity_id else {}
-            fields[vol.Required(CONF_SOURCE_ENTITY_ID, **kw)] = _ENTITY_SEL
+            fields[vol.Optional(CONF_SOURCE_ENTITY_ID, **kw)] = _ENTITY_SEL
     fields[vol.Optional(CONF_DISPLAY_NAME, default=display_name)] = selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT))
     fields[vol.Required(CONF_CATEGORY, default=category)] = selector.SelectSelector(
         selector.SelectSelectorConfig(options=_CATEGORY_OPTIONS, multiple=False, mode=selector.SelectSelectorMode.DROPDOWN)
@@ -231,8 +231,14 @@ def _step3_schema(opts: dict[str, Any], maw_sources: list[str], control_map: dic
 
     chosen_sources: list[str] = list(opts.get(CONF_COMBINED_SOURCES, []))
     if auto_priority:
-        preview = ", ".join(chosen_sources) if chosen_sources else "Auto: no source selected"
-        fields[vol.Optional(_PREVIEW_KEY, default=preview)] = selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT))
+        if maw_sources:
+            fields[vol.Optional(CONF_COMBINED_SOURCES, default=chosen_sources)] = selector.SelectSelector(
+                selector.SelectSelectorConfig(options=maw_sources, multiple=True, mode=selector.SelectSelectorMode.LIST)
+            )
+        else:
+            fields[vol.Optional(_NO_MAW_INFO, default="Keine MAW-Instanzen gefunden. Bitte zuerst einzelne Player konfigurieren.")] = selector.TextSelector(
+                selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+            )
     else:
         slot_defaults = _combined_sources_to_slots(chosen_sources)
         if not maw_sources:
@@ -267,6 +273,7 @@ class MediaCoverArtConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._entity_kind: str = ENTITY_KIND_WRAPPER
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
+        errors: dict[str, str] = {}
         if user_input is not None:
             draft = {**self._step1_draft, **user_input}
             selected_kind = draft.get(CONF_ENTITY_KIND, ENTITY_KIND_WRAPPER)
@@ -276,30 +283,47 @@ class MediaCoverArtConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 or selected_category != self._step1_draft.get(CONF_CATEGORY, CATEGORY_AUTO)
             ):
                 self._step1_draft = draft
-                return self.async_show_form(step_id="user", data_schema=_step1_schema(include_source=True, **draft))
+                return self.async_show_form(step_id="user", data_schema=_step1_schema(include_source=True, **{k: v for k, v in draft.items() if k in (CONF_SOURCE_ENTITY_ID, CONF_DISPLAY_NAME, CONF_CATEGORY, CONF_ENTITY_KIND)}))
 
             self._entity_kind = selected_kind
             source_entity_id = draft.get(CONF_SOURCE_ENTITY_ID)
-            if self._entity_kind != ENTITY_KIND_COMBINED_ONLY and source_entity_id:
-                await self.async_set_unique_id(source_entity_id)
-                self._abort_if_unique_id_configured()
 
-            display_name = str(draft.get(CONF_DISPLAY_NAME, "")).strip()
-            if not display_name and source_entity_id:
-                display_name = await _friendly_name(self.hass, source_entity_id)
+            if self._entity_kind != ENTITY_KIND_COMBINED_ONLY and not source_entity_id:
+                errors[CONF_SOURCE_ENTITY_ID] = "source_entity_required"
 
-            self._step1 = {
-                CONF_SOURCE_ENTITY_ID: source_entity_id,
-                CONF_DISPLAY_NAME: display_name,
-                CONF_CATEGORY: selected_category,
-            }
-            if self._entity_kind == ENTITY_KIND_COMBINED_ONLY:
-                self._step2 = {}
-                self._step3[CONF_CREATE_COMBINED] = True
-                return await self.async_step_combined()
-            return await self.async_step_artwork()
+            if not errors:
+                if self._entity_kind != ENTITY_KIND_COMBINED_ONLY and source_entity_id:
+                    await self.async_set_unique_id(source_entity_id)
+                    self._abort_if_unique_id_configured()
 
-        return self.async_show_form(step_id="user", data_schema=_step1_schema(include_source=True, entity_kind=self._entity_kind))
+                display_name = str(draft.get(CONF_DISPLAY_NAME, "")).strip()
+                if not display_name and source_entity_id:
+                    display_name = await _friendly_name(self.hass, source_entity_id)
+
+                self._step1 = {
+                    CONF_SOURCE_ENTITY_ID: source_entity_id,
+                    CONF_DISPLAY_NAME: display_name,
+                    CONF_CATEGORY: selected_category,
+                }
+                if self._entity_kind == ENTITY_KIND_COMBINED_ONLY:
+                    self._step2 = {}
+                    self._step3[CONF_CREATE_COMBINED] = True
+                    return await self.async_step_combined()
+                return await self.async_step_artwork()
+
+            self._step1_draft = draft
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=_step1_schema(
+                include_source=True,
+                source_entity_id=self._step1_draft.get(CONF_SOURCE_ENTITY_ID),
+                display_name=str(self._step1_draft.get(CONF_DISPLAY_NAME, "")),
+                category=str(self._step1_draft.get(CONF_CATEGORY, CATEGORY_AUTO)),
+                entity_kind=self._step1_draft.get(CONF_ENTITY_KIND, self._entity_kind),
+            ),
+            errors=errors,
+        )
 
     async def async_step_artwork(self, user_input: dict[str, Any] | None = None):
         category = self._step1.get(CONF_CATEGORY, CATEGORY_AUTO)
@@ -356,6 +380,7 @@ class MediaCoverArtConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             new_auto = bool(draft.get(CONF_AUTO_PRIORITY, True))
             if new_create != prev_create or (new_create and new_auto != prev_auto):
                 selected = list(draft.get(CONF_COMBINED_SOURCES, [])) or _combined_slots_to_sources(draft)
+                draft[CONF_COMBINED_SOURCES] = selected
                 draft[CONF_COMBINED_AUDIO_SOURCES] = [control_map[s] for s in selected if control_map.get(s)]
                 self._step3 = draft
                 return self.async_show_form(step_id="combined", data_schema=_step3_schema(draft, maw_sources, control_map, force_combined=self._entity_kind == ENTITY_KIND_COMBINED_ONLY))
@@ -482,6 +507,7 @@ class MediaCoverArtOptionsFlow(config_entries.OptionsFlowWithConfigEntry):
             new_auto = bool(draft.get(CONF_AUTO_PRIORITY, True))
             if new_create != prev_create or (new_create and new_auto != prev_auto):
                 selected = list(draft.get(CONF_COMBINED_SOURCES, [])) or _combined_slots_to_sources(draft)
+                draft[CONF_COMBINED_SOURCES] = selected
                 draft[CONF_COMBINED_AUDIO_SOURCES] = [control_map[s] for s in selected if control_map.get(s)]
                 self._combined_opts = draft
                 return self.async_show_form(step_id="combined", data_schema=_step3_schema(draft, maw_sources, control_map))

--- a/custom_components/media_art_wrapper/media_player.py
+++ b/custom_components/media_art_wrapper/media_player.py
@@ -15,10 +15,11 @@ from .const import (
     CATEGORY_SORT_PRIORITY,
     CONF_AUTO_PRIORITY,
     CONF_COMBINED_AUDIO_SOURCES,
+    CONF_COMBINED_DELEGATE_PREFIX,
     CONF_COMBINED_NAME,
-    CONF_CREATE_WRAPPER,
     CONF_COMBINED_SOURCES,
     CONF_CREATE_COMBINED,
+    CONF_CREATE_WRAPPER,
     CONF_SOURCE_ENTITY_ID,
     DOMAIN,
 )
@@ -113,20 +114,31 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         entities.append(MediaCoverArtUniversalPlayer(coordinator, entry))
 
     create_combined, combined_name, combined_sources, combined_audio, auto_priority = _get_combined_config(entry)
-    if create_combined and combined_name and combined_sources:
-        display_sources, auto_audio_sources = _resolve_combined_sources(hass, combined_sources)
-        if auto_priority:
-            display_sources = _sort_sources_by_category(display_sources, hass)
-        control_sources = combined_audio or auto_audio_sources
-        slot_delegate_map: dict[str, str] = {}
-        for idx, wrapper in enumerate(combined_sources, start=1):
-            delegate = entry.options.get(f"{CONF_COMBINED_DELEGATE_PREFIX}{idx}")
-            if not isinstance(delegate, str) or not delegate.strip():
-                continue
-            resolved_display, _ = _resolve_combined_sources(hass, [wrapper])
-            if resolved_display:
-                slot_delegate_map[resolved_display[0]] = delegate.strip()
-        entities.append(CombinedMediaPlayer(hass, entry, display_sources, control_sources, combined_name, slot_delegate_map))
+    if create_combined and combined_name:
+        if not combined_sources and auto_priority:
+            registry = er.async_get(hass)
+            discovered: list[str] = []
+            for cfg_entry in hass.config_entries.async_entries(DOMAIN):
+                if cfg_entry.entry_id == entry.entry_id:
+                    continue
+                for entity_entry in er.async_entries_for_config_entry(registry, cfg_entry.entry_id):
+                    if entity_entry.domain == "media_player" and entity_entry.unique_id.endswith("_cover_player") and entity_entry.entity_id:
+                        discovered.append(entity_entry.entity_id)
+            combined_sources = sorted(set(discovered))
+        if combined_sources:
+            display_sources, auto_audio_sources = _resolve_combined_sources(hass, combined_sources)
+            if auto_priority:
+                display_sources = _sort_sources_by_category(display_sources, hass)
+            control_sources = combined_audio or auto_audio_sources
+            slot_delegate_map: dict[str, str] = {}
+            for idx, wrapper in enumerate(combined_sources, start=1):
+                delegate = entry.options.get(f"{CONF_COMBINED_DELEGATE_PREFIX}{idx}")
+                if not isinstance(delegate, str) or not delegate.strip():
+                    continue
+                resolved_display, _ = _resolve_combined_sources(hass, [wrapper])
+                if resolved_display:
+                    slot_delegate_map[resolved_display[0]] = delegate.strip()
+            entities.append(CombinedMediaPlayer(hass, entry, display_sources, control_sources, combined_name, slot_delegate_map))
 
     async_add_entities(entities, update_before_add=False)
 

--- a/custom_components/media_art_wrapper/translations/de.json
+++ b/custom_components/media_art_wrapper/translations/de.json
@@ -5,12 +5,14 @@
         "title": "Media Art Wrapper — Player",
         "description": "Wähle einen Media Player aus und lege fest, wie dessen Inhalte kategorisiert werden sollen.",
         "data": {
+          "entity_kind": "Integrationstyp",
           "source_entity_id": "Media Player",
           "display_name": "Anzeigename",
           "category": "Inhaltskategorie"
         },
         "data_description": {
-          "source_entity_id": "Die Media-Player-Entity, deren Artwork ermittelt werden soll.",
+          "entity_kind": "Wähle ob ein Wrapper-Player, ein kombinierter Player oder beides erstellt werden soll.",
+          "source_entity_id": "Die Media-Player-Entity, deren Artwork ermittelt werden soll. Pflichtfeld für Wrapper-Typen.",
           "display_name": "In Home Assistant angezeigter Name. Leer lassen, um den Playernamen zu verwenden.",
           "category": "Bestimmt, welche Artwork-Provider verwendet werden. Auto probiert alle Provider."
         }
@@ -52,6 +54,7 @@
           "create_combined": "Kombinierten Player erstellen",
           "combined_name": "Name des kombinierten Players",
           "auto_priority": "Priorität automatisch aus Kategorie ableiten",
+          "combined_sources": "Quellen (leer lassen um alle konfigurierten Wrapper zu verwenden)",
           "combined_source_1": "Quelle 1 (höchste Priorität)",
           "combined_source_2": "Quelle 2",
           "combined_source_3": "Quelle 3",
@@ -74,6 +77,7 @@
           "create_combined": "Wenn aktiviert, werden eine virtuelle media_player-Entity und eine Cover-Bild-Entity erstellt, die die unten angegebenen Quellen zusammenfassen.",
           "combined_name": "Wird für die Entity-Namen verwendet: media_player.NAME und image.NAME_cover. Nur Kleinbuchstaben und Unterstriche.",
           "auto_priority": "Gaming hat höchste Priorität, dann Streaming, TV, Musik, Auto.",
+          "combined_sources": "Wähle die MAW-Wrapper-Player für den kombinierten Player. Leer lassen um alle automatisch einzubeziehen.",
           "combined_source_1": "Prioritätsreihenfolge: PLAYING oder BUFFERING schlägt PAUSED oder IDLE, was ON schlägt. Bei gleichem Status gewinnt die niedrigere Slotnummer.",
           "combined_audio_sources": "Entitäten die Lautstärke, Shuffle und Wiedergabebefehle empfangen. Falls leer, werden Befehle an die aktive Anzeigeentität gesendet.",
           "combined_delegate_1": "Falls gesetzt, werden Browse, Queue und Steuerungsbefehle an diese Entität weitergeleitet. Nützlich z.B. für Music Assistant bei HomePods oder native PS5-Steuerung.",
@@ -142,6 +146,7 @@
           "create_combined": "Kombinierten Player erstellen",
           "combined_name": "Name des kombinierten Players",
           "auto_priority": "Priorität automatisch aus Kategorie ableiten",
+          "combined_sources": "Quellen (leer lassen um alle konfigurierten Wrapper zu verwenden)",
           "combined_source_1": "Quelle 1 (höchste Priorität)",
           "combined_source_2": "Quelle 2",
           "combined_source_3": "Quelle 3",
@@ -164,6 +169,7 @@
           "create_combined": "Wenn aktiviert, werden eine virtuelle media_player-Entity und eine Cover-Bild-Entity erstellt, die die unten angegebenen Quellen zusammenfassen.",
           "combined_name": "Wird für die Entity-Namen verwendet: media_player.NAME und image.NAME_cover. Nur Kleinbuchstaben und Unterstriche.",
           "auto_priority": "Gaming hat höchste Priorität, dann Streaming, TV, Musik, Auto.",
+          "combined_sources": "Wähle die MAW-Wrapper-Player für den kombinierten Player. Leer lassen um alle automatisch einzubeziehen.",
           "combined_source_1": "Prioritätsreihenfolge: PLAYING oder BUFFERING schlägt PAUSED oder IDLE, was ON schlägt. Bei gleichem Status gewinnt die niedrigere Slotnummer.",
           "combined_audio_sources": "Entitäten die Lautstärke, Shuffle und Wiedergabebefehle empfangen. Falls leer, werden Befehle an die aktive Anzeigeentität gesendet.",
           "combined_delegate_1": "Falls gesetzt, werden Browse, Queue und Steuerungsbefehle an diese Entität weitergeleitet. Nützlich z.B. für Music Assistant bei HomePods oder native PS5-Steuerung.",
@@ -179,6 +185,7 @@
     }
   },
   "errors": {
-    "combined_name_required": "Ein Name ist erforderlich, wenn der kombinierte Player aktiviert ist."
+    "combined_name_required": "Ein Name ist erforderlich, wenn der kombinierte Player aktiviert ist.",
+    "source_entity_required": "Ein Media-Player ist für diesen Integrationstyp erforderlich."
   }
 }

--- a/custom_components/media_art_wrapper/translations/en.json
+++ b/custom_components/media_art_wrapper/translations/en.json
@@ -5,12 +5,14 @@
         "title": "Media Art Wrapper — Player",
         "description": "Select the media player to wrap and choose how its content should be categorised.",
         "data": {
+          "entity_kind": "Integration type",
           "source_entity_id": "Media player",
           "display_name": "Display name",
           "category": "Content category"
         },
         "data_description": {
-          "source_entity_id": "The media player entity whose artwork will be resolved.",
+          "entity_kind": "Choose whether to create a wrapper player, a combined player, or both.",
+          "source_entity_id": "The media player entity whose artwork will be resolved. Required for wrapper types.",
           "display_name": "Friendly name shown in Home Assistant. Leave blank to use the player name.",
           "category": "Determines which artwork providers are used. Choose Auto to try all providers."
         }
@@ -52,6 +54,7 @@
           "create_combined": "Create combined player",
           "combined_name": "Combined player name",
           "auto_priority": "Auto-derive priority from category",
+          "combined_sources": "Sources (leave empty to use all configured wrappers)",
           "combined_source_1": "Source 1 (highest priority)",
           "combined_source_2": "Source 2",
           "combined_source_3": "Source 3",
@@ -142,6 +145,7 @@
           "create_combined": "Create combined player",
           "combined_name": "Combined player name",
           "auto_priority": "Auto-derive priority from category",
+          "combined_sources": "Sources (leave empty to use all configured wrappers)",
           "combined_source_1": "Source 1 (highest priority)",
           "combined_source_2": "Source 2",
           "combined_source_3": "Source 3",
@@ -164,6 +168,7 @@
           "create_combined": "When enabled, creates a virtual media_player entity and a cover image entity aggregating the sources below.",
           "combined_name": "Used to name the entities: media_player.NAME and image.NAME_cover. Use lowercase letters and underscores only.",
           "auto_priority": "Gaming has highest priority, then Streaming, TV, Music, Auto.",
+          "combined_sources": "Select the MAW wrapper players for the combined player. Leave empty to include all automatically.",
           "combined_source_1": "Priority ordered: PLAYING or BUFFERING beats PAUSED or IDLE, which beats ON. Lower slot number wins within the same tier.",
           "combined_audio_sources": "Entities that receive volume, shuffle and playback commands. If empty, commands are sent to the active display entity.",
           "combined_delegate_1": "If set, browse, queue and control commands are forwarded to this entity. Useful for Music Assistant with HomePods or native PS5 control.",
@@ -179,6 +184,7 @@
     }
   },
   "errors": {
-    "combined_name_required": "A name is required when the combined player is enabled."
+    "combined_name_required": "A name is required when the combined player is enabled.",
+    "source_entity_required": "A media player entity is required for this integration type."
   }
 }


### PR DESCRIPTION
## Summary
This PR enhances the Media Art Wrapper configuration flow to improve the combined player setup experience and add better validation for required fields.

## Key Changes

- **Made source entity optional for combined-only mode**: Changed `CONF_SOURCE_ENTITY_ID` from required to optional in the schema, allowing users to create combined players without individual wrapper players.

- **Added validation for source entity**: Implemented proper error handling in `async_step_user()` to validate that a source entity is provided when creating wrapper-type players, with user-friendly error messages.

- **Improved combined player source selection**: 
  - Modified `_step3_schema()` to display a multi-select dropdown for choosing MAW sources when auto-priority is enabled
  - Added fallback message when no MAW instances are available
  - Implemented automatic discovery of configured wrapper players when combined sources are empty and auto-priority is enabled

- **Fixed form state persistence**: Enhanced the user step form to properly preserve and restore draft values across validation errors, including proper parameter filtering when re-rendering the schema.

- **Updated translations**: Added German and English translations for:
  - New "Integration type" field description
  - Updated source entity field descriptions to clarify it's required for wrapper types
  - New "combined_sources" field labels and descriptions
  - New validation error message for missing source entity

- **Code organization**: Sorted imports alphabetically in `media_player.py` for consistency.

## Implementation Details

The combined player now supports two workflows:
1. **Manual selection**: Users can explicitly choose which wrapper players to include in the combined player
2. **Automatic discovery**: When sources are left empty and auto-priority is enabled, the system automatically discovers all configured wrapper players from other config entries

This allows for more flexible configuration where users can create a combined player without pre-configuring individual wrappers, and the system will automatically include them as they're added later.

https://claude.ai/code/session_0146Aq5gq3PUvH1CTwtP1Sop