### PR TITLE
Implement smart_player steps 7-10: adult providers, game DB, EPG config and Stash integration

### DIFF
--- a/custom_components/media_art_wrapper/__init__.py
+++ b/custom_components/media_art_wrapper/__init__.py
@@ -28,6 +28,7 @@ from .const import (
     CONF_MAW_SENSOR_TV_INPUT,
     CONF_SOURCE_ENTITY_ID,
     CONF_EPG_SENSOR,
+    CONF_EPG_FULL_LOOKUP_CHANNELS,
     COMBINED_NUM_SOURCE_SLOTS,
     DEFAULT_ARTWORK_HEIGHT,
     DEFAULT_ARTWORK_SIZE,
@@ -35,6 +36,7 @@ from .const import (
     DEFAULT_MAW_SENSOR_DISCORD_GAME,
     DEFAULT_MAW_SENSOR_STASH_ACTIVE,
     DEFAULT_MAW_SENSOR_TV_INPUT,
+    DEFAULT_EPG_FULL_LOOKUP_CHANNELS,
     DOMAIN,
     FALLBACK_PLACEHOLDER,
     PLATFORMS,
@@ -141,6 +143,7 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
         self._sensor_tv_input: str = ""
         self._sensor_discord_game: str = ""
         self._sensor_stash_active: str = ""
+        self._epg_full_lookup_channels: set[str] = set(DEFAULT_EPG_FULL_LOOKUP_CHANNELS)
 
         super().__init__(
             hass=hass,
@@ -186,6 +189,14 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
             opts.get(CONF_MAW_SENSOR_STASH_ACTIVE,
                      data.get(CONF_MAW_SENSOR_STASH_ACTIVE, DEFAULT_MAW_SENSOR_STASH_ACTIVE))
         ).strip()
+        raw_channels = opts.get(CONF_EPG_FULL_LOOKUP_CHANNELS, data.get(CONF_EPG_FULL_LOOKUP_CHANNELS))
+        if isinstance(raw_channels, str):
+            parsed = {part.strip() for part in raw_channels.split(",") if part.strip()}
+        elif isinstance(raw_channels, (list, tuple, set)):
+            parsed = {str(part).strip() for part in raw_channels if str(part).strip()}
+        else:
+            parsed = set(DEFAULT_EPG_FULL_LOOKUP_CHANNELS)
+        self._epg_full_lookup_channels = parsed or set(DEFAULT_EPG_FULL_LOOKUP_CHANNELS)
 
     def _tracked_entity_ids(self) -> list[str]:
         """Source plus §7.1 context sensors used by the §2.3 detector."""
@@ -388,6 +399,7 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
                     category=self.category,
                     artwork_width=self.artwork_width,
                     artwork_height=self.artwork_height,
+                    epg_full_lookup_channels=self._epg_full_lookup_channels,
                 )
 
                 # §2.3 prios 2-8 — hierarchy dispatch driven by §7.1 sensors.
@@ -397,6 +409,7 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
                     discord_game_state=self._sensor_state_str(self._sensor_discord_game),
                     stash_active_state=self._sensor_state_str(self._sensor_stash_active),
                     channel_name=query.channel_name,
+                    epg_full_lookup_channels=self._epg_full_lookup_channels,
                 )
                 resolved = await resolve_hierarchy(
                     session=self._session,
@@ -428,7 +441,7 @@ class CoverCoordinator(DataUpdateCoordinator[CoverData]):
                 source_entity_id=self.source_entity_id,
                 track_key=track_key,
                 artist=artist,
-                title=title,
+                title=query.title or title,
                 album=album,
                 provider=resolved.provider_name,
                 artwork_url=resolved.image_url,

--- a/custom_components/media_art_wrapper/config_flow.py
+++ b/custom_components/media_art_wrapper/config_flow.py
@@ -48,8 +48,14 @@ from .const import (
     CONF_RATIO,
     CONF_SOURCE_ENTITY_ID,
     CONF_STEAMGRIDDB_API_KEY,
+    CONF_STASH_API_KEY,
+    CONF_STASH_HOST_REWRITE,
+    CONF_STASH_URL,
+    CONF_STASHDB_API_KEY,
     CONF_TMDB_API_KEY,
     CONF_EPG_SENSOR,
+    CONF_EPG_FULL_LOOKUP_CHANNELS,
+    DEFAULT_EPG_FULL_LOOKUP_CHANNELS,
     DEFAULT_ARTWORK_HEIGHT,
     DEFAULT_ARTWORK_WIDTH,
     DEFAULT_CMP_SENSOR_HOMEPODS_ACTIVE,
@@ -247,6 +253,10 @@ def _step2_schema(category: str, opts: dict[str, Any]) -> vol.Schema:
         fields[vol.Optional(CONF_EPG_SENSOR, default=opts.get(CONF_EPG_SENSOR))] = selector.EntitySelector(
             selector.EntitySelectorConfig(domain="sensor", multiple=False)
         )
+        fields[vol.Optional(
+            CONF_EPG_FULL_LOOKUP_CHANNELS,
+            default=", ".join(opts.get(CONF_EPG_FULL_LOOKUP_CHANNELS, DEFAULT_EPG_FULL_LOOKUP_CHANNELS)),
+        )] = selector.TextSelector(selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT))
 
     # §2.3 hierarchy detector — context sensors per LASTENHEFT §7.1.
     # Always shown (drives prio 2-7 dispatching independent of category).
@@ -265,6 +275,18 @@ def _step2_schema(category: str, opts: dict[str, Any]) -> vol.Schema:
         CONF_MAW_SENSOR_STASH_ACTIVE,
         default=opts.get(CONF_MAW_SENSOR_STASH_ACTIVE, DEFAULT_MAW_SENSOR_STASH_ACTIVE),
     )] = sensor_selector
+    fields[vol.Optional(CONF_STASH_URL, default=opts.get(CONF_STASH_URL, ""))] = selector.TextSelector(
+        selector.TextSelectorConfig(type=selector.TextSelectorType.URL)
+    )
+    fields[vol.Optional(CONF_STASH_API_KEY, default=opts.get(CONF_STASH_API_KEY, ""))] = selector.TextSelector(
+        selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+    )
+    fields[vol.Optional(CONF_STASHDB_API_KEY, default=opts.get(CONF_STASHDB_API_KEY, ""))] = selector.TextSelector(
+        selector.TextSelectorConfig(type=selector.TextSelectorType.PASSWORD)
+    )
+    fields[vol.Optional(CONF_STASH_HOST_REWRITE, default=opts.get(CONF_STASH_HOST_REWRITE, ""))] = selector.TextSelector(
+        selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+    )
 
     return vol.Schema(fields)
 

--- a/custom_components/media_art_wrapper/const.py
+++ b/custom_components/media_art_wrapper/const.py
@@ -142,8 +142,13 @@ CONF_IGDB_CLIENT_ID = "igdb_client_id"
 CONF_IGDB_CLIENT_SECRET = "igdb_client_secret"
 CONF_STEAMGRIDDB_API_KEY = "steamgriddb_api_key"
 CONF_FANART_API_KEY = "fanart_api_key"
+CONF_STASH_URL = "stash_url"
+CONF_STASH_API_KEY = "stash_api_key"
+CONF_STASH_HOST_REWRITE = "stash_host_rewrite"
+CONF_STASHDB_API_KEY = "stashdb_api_key"
 CONF_XMLTV_URL = "xmltv_url"  # Reserved for EPG v3.2 — not yet implemented; kept in storage only
 CONF_EPG_SENSOR = "epg_sensor"
+CONF_EPG_FULL_LOOKUP_CHANNELS = "epg_full_lookup_channels"
 
 # ---------------------------------------------------------------------------
 # §2.3 Artwork-hierarchy detector sensors (per §7.1)
@@ -215,10 +220,9 @@ DEFAULT_CMP_SENSOR_HOMEPODS_ACTIVE = "binary_sensor.homepods_active_atomic"
 # ---------------------------------------------------------------------------
 # Channels in this set trigger full API lookups (TVMaze + TMDb episode search).
 # All other channels (private/commercial) receive channel_icon directly.
-EPG_FULL_LOOKUP_CHANNELS: frozenset[str] = frozenset({
+DEFAULT_EPG_FULL_LOOKUP_CHANNELS: tuple[str, ...] = (
     # ARD Familie
-    "Das Erste", "ARD", "ARD HD", "Das Erste HD",
-    "tagesschau24", "ONE", "ARD alpha",
+    "Das Erste", "ARD", "ARD HD", "Das Erste HD", "tagesschau24", "ONE", "ARD alpha",
     # ZDF Familie
     "ZDF", "ZDF HD", "ZDFinfo", "ZDFneo", "ZDF Krimi", "3sat",
     # WDR
@@ -227,4 +231,6 @@ EPG_FULL_LOOKUP_CHANNELS: frozenset[str] = frozenset({
     "arte", "arte HD",
     "NDR", "MDR", "SWR", "BR", "HR", "RBB",
     "Phoenix", "KiKA",
-})
+)
+
+EPG_FULL_LOOKUP_CHANNELS: frozenset[str] = frozenset(DEFAULT_EPG_FULL_LOOKUP_CHANNELS)

--- a/custom_components/media_art_wrapper/providers/__init__.py
+++ b/custom_components/media_art_wrapper/providers/__init__.py
@@ -25,14 +25,21 @@ from ..const import (
     CONF_FANART_API_KEY,
     CONF_IGDB_CLIENT_ID,
     CONF_IGDB_CLIENT_SECRET,
+    CONF_STASH_API_KEY,
+    CONF_STASH_HOST_REWRITE,
+    CONF_STASH_URL,
+    CONF_STASHDB_API_KEY,
     CONF_STEAMGRIDDB_API_KEY,
     CONF_TMDB_API_KEY,
-    EPG_FULL_LOOKUP_CHANNELS,
 )
 from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+from .aebn import AEBNProvider
 from .fanart import FanartTvProvider
 from .igdb import IGDBProvider
 from .itunes import ITunesProvider
+from .porndb import PornDBProvider
+from .stash import StashProvider
+from .stashdb import StashDBProvider
 from .musicbrainz import MusicBrainzProvider
 from .steamgriddb import SteamGridDBProvider, SteamProvider
 from .tmdb import TMDbProvider
@@ -58,9 +65,7 @@ def build_provider_instances(options: dict[str, Any]) -> dict[str, ArtworkProvid
     credentials are missing are still returned — callers must filter on
     ``is_available()``.
 
-    TODO Schritt 7 (§3.2 / §6): wire StashClient, StashDBProvider,
-    PornDBProvider and AEBNProvider — keys "stash", "stashdb", "porndb",
-    "aebn" are already routed via CATEGORY_PROVIDERS[CATEGORY_ADULT].
+    Includes §6.4 adult provider chain: stash -> stashdb -> porndb -> aebn.
     """
     return {
         "itunes": ITunesProvider(),
@@ -74,6 +79,14 @@ def build_provider_instances(options: dict[str, Any]) -> dict[str, ArtworkProvid
         "steam": SteamProvider(),
         "tvmaze": TVMazeProvider(),
         "fanart": FanartTvProvider(options.get(CONF_FANART_API_KEY, "")),
+        "stash": StashProvider(
+            options.get(CONF_STASH_URL, ""),
+            options.get(CONF_STASH_API_KEY, ""),
+            options.get(CONF_STASH_HOST_REWRITE, ""),
+        ),
+        "stashdb": StashDBProvider(options.get(CONF_STASHDB_API_KEY, "")),
+        "porndb": PornDBProvider(),
+        "aebn": AEBNProvider(),
     }
 
 
@@ -119,7 +132,8 @@ async def resolve_cover(
     # TV: private/commercial channels → return channel_icon directly, skip API lookups
     if query.category == "tv" and query.channel_name:
         raw_channel = (query.channel_name or "").strip()
-        if raw_channel and raw_channel not in EPG_FULL_LOOKUP_CHANNELS:
+        full_lookup_channels = query.epg_full_lookup_channels or set()
+        if raw_channel and raw_channel not in full_lookup_channels:
             if query.channel_icon:
                 _LOGGER.debug(
                     "Private channel %r — returning channel_icon directly (no API call)",

--- a/custom_components/media_art_wrapper/providers/aebn.py
+++ b/custom_components/media_art_wrapper/providers/aebn.py
@@ -1,0 +1,48 @@
+"""AEBN provider (REST fallback)."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+
+AEBN_SEARCH_URL = "https://api.aebn.net/v1/titles"
+_JSON_KW = {"content_type": None}
+
+
+class AEBNProvider(ArtworkProvider):
+    categories = frozenset({"adult"})
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        title = (query.title or "").strip()
+        if not title:
+            return None
+
+        try:
+            async with session.get(
+                AEBN_SEARCH_URL,
+                params={"query": title, "limit": 1},
+                timeout=10,
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                payload: dict[str, Any] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("AEBN lookup failed for %r: %s", title, err)
+            return None
+
+        items = payload.get("items") if isinstance(payload, dict) else None
+        if not isinstance(items, list) or not items:
+            return None
+
+        first = items[0] if isinstance(items[0], dict) else None
+        if not first:
+            return None
+
+        image_url = first.get("cover") or first.get("image")
+        if not isinstance(image_url, str) or not image_url:
+            return None
+
+        return ArtworkResult(provider_name="aebn", image_url=image_url, confidence=0.74)

--- a/custom_components/media_art_wrapper/providers/base.py
+++ b/custom_components/media_art_wrapper/providers/base.py
@@ -25,6 +25,7 @@ class ArtworkQuery:
     subtitle_hint: str = ""
     channel_icon: str = ""      # og:image or EPG-supplied channel logo URL
     channel_name: str = ""      # raw channel name from app_name / EPG
+    epg_full_lookup_channels: set[str] = field(default_factory=set)
 
 
 @dataclass(slots=True)

--- a/custom_components/media_art_wrapper/providers/game_db.py
+++ b/custom_components/media_art_wrapper/providers/game_db.py
@@ -1,0 +1,94 @@
+"""Persistent game metadata database (LASTENHEFT §4.2-§4.4)."""
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+_LOGGER = logging.getLogger(__name__)
+
+GAME_DB_PATH = Path("/config/custom_components/smart_player/game_db.json")
+_KEY_RE = re.compile(r"[^a-z0-9]+")
+_LOCK = Lock()
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).replace(microsecond=0).isoformat()
+
+
+def key_for_title(title: str) -> str:
+    return _KEY_RE.sub("_", title.strip().lower()).strip("_") or "unknown"
+
+
+def _default_entry(title: str) -> dict[str, Any]:
+    return {
+        "canonical_title": title,
+        "sgdb_id": None,
+        "igdb_id": None,
+        "logo_url": None,
+        "logo_override_url": None,
+        "logo_cached_path": None,
+        "cover_cached_path": None,
+        "cover_url": None,
+        "last_seen": _now_iso(),
+        "play_count": 0,
+        "lookup_failed": False,
+    }
+
+
+def _load() -> dict[str, dict[str, Any]]:
+    if not GAME_DB_PATH.exists():
+        return {}
+    try:
+        payload = json.loads(GAME_DB_PATH.read_text(encoding="utf-8"))
+    except Exception as err:
+        _LOGGER.debug("game_db load failed: %s", err)
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _save(data: dict[str, dict[str, Any]]) -> None:
+    GAME_DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    GAME_DB_PATH.write_text(json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def touch_title(title: str) -> dict[str, Any]:
+    key = key_for_title(title)
+    with _LOCK:
+        db = _load()
+        entry = db.get(key)
+        if not isinstance(entry, dict):
+            entry = _default_entry(title)
+        entry["canonical_title"] = str(entry.get("canonical_title") or title)
+        entry["last_seen"] = _now_iso()
+        entry["play_count"] = int(entry.get("play_count") or 0) + 1
+        db[key] = entry
+        _save(db)
+        return dict(entry)
+
+
+def update_title(title: str, **fields: Any) -> dict[str, Any]:
+    key = key_for_title(title)
+    with _LOCK:
+        db = _load()
+        entry = db.get(key)
+        if not isinstance(entry, dict):
+            entry = _default_entry(title)
+        for k, v in fields.items():
+            entry[k] = v
+        entry["last_seen"] = _now_iso()
+        db[key] = entry
+        _save(db)
+        return dict(entry)
+
+
+def get_title(title: str) -> dict[str, Any] | None:
+    key = key_for_title(title)
+    with _LOCK:
+        db = _load()
+        entry = db.get(key)
+        return dict(entry) if isinstance(entry, dict) else None

--- a/custom_components/media_art_wrapper/providers/hierarchy.py
+++ b/custom_components/media_art_wrapper/providers/hierarchy.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from ..const import (
     CATEGORY_ADULT,
-    EPG_FULL_LOOKUP_CHANNELS,
     SCENARIO_ATV_NO_TITLE,
     SCENARIO_ATV_TITLE,
     SCENARIO_FALLBACK,
@@ -47,6 +46,7 @@ def detect_scenario(
     discord_game_state: str | None,
     stash_active_state: str | None,
     channel_name: str = "",
+    epg_full_lookup_channels: set[str] | None = None,
 ) -> ScenarioContext:
     """Classify which §2.3 priority applies for the current context.
 
@@ -79,7 +79,8 @@ def detect_scenario(
 
     # Prio 6 / 7 — TV / Sat
     if tv_input == "live_tv":
-        in_list = bool(channel_name and channel_name.strip() in EPG_FULL_LOOKUP_CHANNELS)
+        configured_channels = epg_full_lookup_channels or set()
+        in_list = bool(channel_name and channel_name.strip() in configured_channels)
         return ScenarioContext(
             SCENARIO_TV_IN_LIST if in_list else SCENARIO_TV_OUT_OF_LIST,
             channel_in_list=in_list,

--- a/custom_components/media_art_wrapper/providers/igdb.py
+++ b/custom_components/media_art_wrapper/providers/igdb.py
@@ -6,6 +6,7 @@ import time
 from typing import Any
 
 from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+from .game_db import get_title, touch_title, update_title
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,6 +67,13 @@ class IGDBProvider(ArtworkProvider):
         if not title:
             return None
 
+        db_entry = touch_title(title)
+        if db_entry.get("lookup_failed"):
+            return None
+        cached_cover = db_entry.get("cover_url")
+        if isinstance(cached_cover, str) and cached_cover:
+            return ArtworkResult(provider_name="igdb", image_url=cached_cover, confidence=0.95)
+
         token = await _get_access_token(session, self._client_id, self._client_secret)
         if not token:
             return None
@@ -88,9 +96,11 @@ class IGDBProvider(ArtworkProvider):
                 games: list[dict[str, Any]] = await resp.json(**_JSON_KW)
         except Exception as err:
             _LOGGER.debug("IGDB game search failed for %r: %s", title, err)
+            update_title(title, lookup_failed=True)
             return None
 
         if not isinstance(games, list) or not games:
+            update_title(title, lookup_failed=True)
             return None
 
         # Pick the first game that has a cover ID
@@ -104,6 +114,7 @@ class IGDBProvider(ArtworkProvider):
                 break
 
         if cover_id is None:
+            update_title(title, lookup_failed=True)
             return None
 
         # Fetch cover URL
@@ -119,13 +130,16 @@ class IGDBProvider(ArtworkProvider):
                 covers: list[dict[str, Any]] = await resp.json(**_JSON_KW)
         except Exception as err:
             _LOGGER.debug("IGDB cover fetch failed: %s", err)
+            update_title(title, lookup_failed=True)
             return None
 
         if not isinstance(covers, list) or not covers:
+            update_title(title, lookup_failed=True)
             return None
 
         image_id = covers[0].get("image_id") if isinstance(covers[0], dict) else None
         if not isinstance(image_id, str):
+            update_title(title, lookup_failed=True)
             return None
 
         # Request highest available quality for preset >=2K
@@ -139,11 +153,14 @@ class IGDBProvider(ArtworkProvider):
                 image = await resp.read()
         except Exception as err:
             _LOGGER.debug("IGDB image download failed: %s", err)
+            update_title(title, lookup_failed=True)
             return None
 
         if not image:
+            update_title(title, lookup_failed=True)
             return None
 
+        update_title(title, igdb_id=cover_id, cover_url=url, lookup_failed=False)
         return ArtworkResult(
             provider_name="igdb",
             image_url=url,

--- a/custom_components/media_art_wrapper/providers/porndb.py
+++ b/custom_components/media_art_wrapper/providers/porndb.py
@@ -1,0 +1,44 @@
+"""PornDB provider (REST fallback)."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+
+PORNDB_SEARCH_URL = "https://api.porndb.me/scenes/search"
+_JSON_KW = {"content_type": None}
+
+
+class PornDBProvider(ArtworkProvider):
+    categories = frozenset({"adult"})
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        title = (query.title or "").strip()
+        if not title:
+            return None
+
+        try:
+            async with session.get(PORNDB_SEARCH_URL, params={"q": title, "limit": 1}, timeout=10) as resp:
+                if resp.status != 200:
+                    return None
+                payload: dict[str, Any] = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("PornDB lookup failed for %r: %s", title, err)
+            return None
+
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, list) or not data:
+            return None
+
+        first = data[0] if isinstance(data[0], dict) else None
+        if not first:
+            return None
+
+        image_url = first.get("image") or first.get("poster")
+        if not isinstance(image_url, str) or not image_url:
+            return None
+
+        return ArtworkResult(provider_name="porndb", image_url=image_url, confidence=0.82)

--- a/custom_components/media_art_wrapper/providers/query_builder.py
+++ b/custom_components/media_art_wrapper/providers/query_builder.py
@@ -127,7 +127,13 @@ def _strip_channel(name: str) -> str:
     return _RE_CHANNEL_SUFFIX.sub("", name).strip()
 
 
-def build_query(state_attrs: dict[str, Any], category: str, artwork_width: int = 600, artwork_height: int = 600) -> ArtworkQuery:
+def build_query(
+    state_attrs: dict[str, Any],
+    category: str,
+    artwork_width: int = 600,
+    artwork_height: int = 600,
+    epg_full_lookup_channels: set[str] | None = None,
+) -> ArtworkQuery:
     raw_title = _raw(state_attrs.get("media_title"))
     clean_title = _clean(state_attrs.get("media_title"))
     artist = _clean(state_attrs.get("media_artist"))
@@ -184,4 +190,5 @@ def build_query(state_attrs: dict[str, Any], category: str, artwork_width: int =
         subtitle_hint=subtitle_hint,
         channel_name=app_name or "",
         channel_icon=str(state_attrs.get("channel_icon") or ""),
+        epg_full_lookup_channels=epg_full_lookup_channels or set(),
     )

--- a/custom_components/media_art_wrapper/providers/stash.py
+++ b/custom_components/media_art_wrapper/providers/stash.py
@@ -1,0 +1,161 @@
+"""Stash provider (local GraphQL scene lookup with screenshot priority)."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+_JSON_KW = {"content_type": None}
+
+FIND_SCENES_QUERY = """
+query FindScenes($query: String!) {
+  findScenes(
+    scene_filter: { title: { value: $query, modifier: INCLUDES } }
+    filter: { per_page: 6 }
+  ) {
+    scenes {
+      id
+      title
+      paths {
+        screenshot
+      }
+      performers {
+        name
+        image_path
+      }
+      studio {
+        name
+        image_path
+      }
+    }
+  }
+}
+"""
+
+SCENE_BY_ID_QUERY = """
+query SceneById($id: ID!) {
+  findScene(id: $id) {
+    id
+    title
+    paths {
+      screenshot
+    }
+    performers {
+      name
+      image_path
+    }
+    studio {
+      name
+      image_path
+    }
+  }
+}
+"""
+
+
+class StashProvider(ArtworkProvider):
+    categories = frozenset({"adult"})
+
+    def __init__(self, base_url: str, api_key: str, host_rewrite: str = "") -> None:
+        self._base_url = (base_url or "").rstrip("/")
+        self._api_key = (api_key or "").strip()
+        self._host_rewrite = (host_rewrite or "").strip()
+
+    def is_available(self) -> bool:
+        return bool(self._base_url)
+
+    def _graphql_url(self) -> str:
+        return f"{self._base_url}/graphql"
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["ApiKey"] = self._api_key
+        return headers
+
+    def _rewrite_url(self, url: str) -> str:
+        if not url.startswith("http"):
+            return url
+        parts = urlsplit(url)
+        if not parts.hostname:
+            return url
+        host = parts.hostname.lower()
+        if host not in {"127.0.0.1", "localhost", "host.docker.internal", "stash", "stashapp"}:
+            return url
+        if not self._host_rewrite:
+            return url
+
+        target = self._host_rewrite
+        if ":" in target:
+            new_host, new_port = target.split(":", 1)
+            try:
+                port = int(new_port)
+            except ValueError:
+                port = parts.port
+        else:
+            new_host, port = target, parts.port
+
+        netloc = f"{new_host}:{port}" if port else new_host
+        return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+    async def _post_graphql(self, session, query: str, variables: dict[str, Any]) -> dict[str, Any] | None:
+        for attempt in range(2):
+            try:
+                async with session.post(
+                    self._graphql_url(),
+                    json={"query": query, "variables": variables},
+                    headers=self._headers(),
+                    timeout=10,
+                ) as resp:
+                    resp.raise_for_status()
+                    payload = await resp.json(**_JSON_KW)
+                if isinstance(payload, dict) and not payload.get("errors"):
+                    data = payload.get("data")
+                    if isinstance(data, dict):
+                        return data
+            except Exception as err:
+                _LOGGER.debug("Stash GraphQL failed (attempt %s): %s", attempt + 1, err)
+            if attempt == 0:
+                await asyncio.sleep(0.2)
+        return None
+
+    def _pick_fallback(self, scene: dict[str, Any]) -> str | None:
+        for performer in scene.get("performers") or []:
+            if isinstance(performer, dict) and isinstance(performer.get("image_path"), str):
+                return self._rewrite_url(performer["image_path"])
+        studio = scene.get("studio")
+        if isinstance(studio, dict) and isinstance(studio.get("image_path"), str):
+            return self._rewrite_url(studio["image_path"])
+        return None
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        title = (query.title or "").strip()
+        if not title:
+            return None
+
+        data = await self._post_graphql(session, FIND_SCENES_QUERY, {"query": title})
+        scenes = ((data or {}).get("findScenes") or {}).get("scenes") or []
+        if not isinstance(scenes, list) or not scenes:
+            return None
+
+        first = scenes[0] if isinstance(scenes[0], dict) else None
+        if not first or not first.get("id"):
+            return None
+
+        detail = await self._post_graphql(session, SCENE_BY_ID_QUERY, {"id": str(first["id"])})
+        scene = (detail or {}).get("findScene") if isinstance(detail, dict) else None
+        if not isinstance(scene, dict):
+            scene = first
+
+        screenshot = ((scene.get("paths") or {}).get("screenshot") if isinstance(scene.get("paths"), dict) else None)
+        if isinstance(screenshot, str) and screenshot:
+            return ArtworkResult(provider_name="stash", image_url=self._rewrite_url(screenshot), confidence=0.97)
+
+        fallback = self._pick_fallback(scene)
+        if fallback:
+            return ArtworkResult(provider_name="stash", image_url=fallback, confidence=0.93)
+        return None

--- a/custom_components/media_art_wrapper/providers/stashdb.py
+++ b/custom_components/media_art_wrapper/providers/stashdb.py
@@ -1,0 +1,144 @@
+"""StashDB provider (GraphQL)."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+
+_LOGGER = logging.getLogger(__name__)
+
+STASHDB_GRAPHQL_URL = "https://stashdb.org/graphql"
+_JSON_KW = {"content_type": None}
+
+# Ported query strings (including SCENE_BY_ID as requested by LASTENHEFT §6.3)
+FIND_SCENES_QUERY = """
+query FindScenes($query: String!) {
+  queryScenes(input: { q: $query, per_page: 6 }) {
+    scenes {
+      id
+      title
+      paths {
+        screenshot
+      }
+      performers {
+        name
+        image_path
+      }
+      studio {
+        name
+        image_path
+      }
+    }
+  }
+}
+"""
+
+SCENE_BY_ID_QUERY = """
+query SceneById($id: ID!) {
+  findScene(id: $id) {
+    id
+    title
+    paths {
+      screenshot
+    }
+    performers {
+      name
+      image_path
+    }
+    studio {
+      name
+      image_path
+    }
+  }
+}
+"""
+
+
+def _pick_image(scene: dict[str, Any]) -> str | None:
+    paths = scene.get("paths") if isinstance(scene, dict) else None
+    if isinstance(paths, dict):
+        screenshot = paths.get("screenshot")
+        if isinstance(screenshot, str) and screenshot:
+            return screenshot
+
+    for performer in scene.get("performers") or []:
+        if not isinstance(performer, dict):
+            continue
+        img = performer.get("image_path")
+        if isinstance(img, str) and img:
+            return img
+
+    studio = scene.get("studio") if isinstance(scene.get("studio"), dict) else None
+    if studio:
+        img = studio.get("image_path")
+        if isinstance(img, str) and img:
+            return img
+    return None
+
+
+class StashDBProvider(ArtworkProvider):
+    """StashDB provider with title-based scene lookup."""
+
+    categories = frozenset({"adult"})
+
+    def __init__(self, api_key: str = "") -> None:
+        self._api_key = (api_key or "").strip()
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self._api_key:
+            headers["ApiKey"] = self._api_key
+        return headers
+
+    async def _graphql(self, session, query: str, variables: dict[str, Any]) -> dict[str, Any] | None:
+        try:
+            async with session.post(
+                STASHDB_GRAPHQL_URL,
+                json={"query": query, "variables": variables},
+                headers=self._headers(),
+                timeout=10,
+            ) as resp:
+                resp.raise_for_status()
+                payload = await resp.json(**_JSON_KW)
+        except Exception as err:
+            _LOGGER.debug("StashDB GraphQL request failed: %s", err)
+            return None
+
+        if not isinstance(payload, dict) or payload.get("errors"):
+            return None
+        data = payload.get("data")
+        return data if isinstance(data, dict) else None
+
+    async def fetch(self, session, query: ArtworkQuery) -> ArtworkResult | None:
+        title = (query.title or "").strip()
+        if not title:
+            return None
+
+        data = await self._graphql(session, FIND_SCENES_QUERY, {"query": title})
+        if not data:
+            return None
+
+        scenes = ((data.get("queryScenes") or {}).get("scenes") or [])
+        if not isinstance(scenes, list) or not scenes:
+            return None
+
+        first = scenes[0] if isinstance(scenes[0], dict) else None
+        if not first:
+            return None
+
+        scene_id = first.get("id")
+        if not scene_id:
+            return None
+
+        # Explicitly call SCENE_BY_ID_QUERY as requested in §6.3.
+        detail = await self._graphql(session, SCENE_BY_ID_QUERY, {"id": str(scene_id)})
+        scene = (detail or {}).get("findScene") if isinstance(detail, dict) else None
+        if not isinstance(scene, dict):
+            scene = first
+
+        image_url = _pick_image(scene)
+        if not image_url:
+            return None
+
+        return ArtworkResult(provider_name="stashdb", image_url=image_url, confidence=0.91)

--- a/custom_components/media_art_wrapper/providers/steamgriddb.py
+++ b/custom_components/media_art_wrapper/providers/steamgriddb.py
@@ -7,6 +7,7 @@ import time
 from typing import Any
 
 from .base import ArtworkProvider, ArtworkQuery, ArtworkResult
+from .game_db import touch_title, update_title
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -112,8 +113,19 @@ class SteamProvider(ArtworkProvider):
         if not title:
             return None
 
+        db_entry = touch_title(title)
+        if db_entry.get("lookup_failed"):
+            return None
+        override_logo = db_entry.get("logo_override_url")
+        if isinstance(override_logo, str) and override_logo:
+            return ArtworkResult(provider_name="steam", image_url=override_logo, confidence=1.0)
+        cached_cover = db_entry.get("cover_url")
+        if isinstance(cached_cover, str) and cached_cover:
+            return ArtworkResult(provider_name="steam", image_url=cached_cover, confidence=0.85)
+
         appid = await _steam_find_appid(session, title)
         if appid is None:
+            update_title(title, lookup_failed=True)
             return None
 
         for template in _STEAM_IMAGE_TEMPLATES:
@@ -130,6 +142,7 @@ class SteamProvider(ArtworkProvider):
                 continue
 
             if image:
+                update_title(title, cover_url=url, lookup_failed=False)
                 return ArtworkResult(
                     provider_name="steam",
                     image_url=url,
@@ -138,6 +151,7 @@ class SteamProvider(ArtworkProvider):
                     content_type=ct,
                 )
 
+        update_title(title, lookup_failed=True)
         return None
 
 
@@ -204,6 +218,7 @@ class SteamGridDBProvider(ArtworkProvider):
 
         game_id = await self._find_game_id(session, title)
         if game_id is None:
+            update_title(title, lookup_failed=True)
             return None
 
         logos_url = SGDB_LOGOS_URL.format(game_id=game_id)
@@ -230,10 +245,12 @@ class SteamGridDBProvider(ArtworkProvider):
 
         first = logos[0]
         if not isinstance(first, dict):
+            update_title(title, lookup_failed=True)
             return None
 
         url = first.get("url")
         if not isinstance(url, str) or not url:
+            update_title(title, lookup_failed=True)
             return None
 
         try:
@@ -246,8 +263,10 @@ class SteamGridDBProvider(ArtworkProvider):
             return None
 
         if not image:
+            update_title(title, lookup_failed=True)
             return None
 
+        update_title(title, cover_url=url, lookup_failed=False)
         return ArtworkResult(
             provider_name="steamgriddb_logo",
             image_url=url,
@@ -260,6 +279,16 @@ class SteamGridDBProvider(ArtworkProvider):
         title = (query.title or "").strip()
         if not title:
             return None
+
+        db_entry = touch_title(title)
+        if db_entry.get("lookup_failed"):
+            return None
+        override_logo = db_entry.get("logo_override_url")
+        if isinstance(override_logo, str) and override_logo:
+            return ArtworkResult(provider_name="steamgriddb", image_url=override_logo, confidence=1.0)
+        cached_cover = db_entry.get("cover_url")
+        if isinstance(cached_cover, str) and cached_cover:
+            return ArtworkResult(provider_name="steamgriddb", image_url=cached_cover, confidence=0.92)
 
         headers = self._auth_headers
         game_id = await self._find_game_id(session, title)
@@ -302,14 +331,17 @@ class SteamGridDBProvider(ArtworkProvider):
 
         grids = grids_data.get("data") or []
         if not isinstance(grids, list) or not grids:
+            update_title(title, lookup_failed=True)
             return None
 
         first = grids[0]
         if not isinstance(first, dict):
+            update_title(title, lookup_failed=True)
             return None
 
         url = first.get("url")
         if not isinstance(url, str) or not url:
+            update_title(title, lookup_failed=True)
             return None
 
         try:
@@ -322,8 +354,10 @@ class SteamGridDBProvider(ArtworkProvider):
             return None
 
         if not image:
+            update_title(title, lookup_failed=True)
             return None
 
+        update_title(title, cover_url=url, lookup_failed=False)
         return ArtworkResult(
             provider_name="steamgriddb",
             image_url=url,


### PR DESCRIPTION
### Motivation
- Implement LASTENHEFT steps §3.2–§6 (Schritt 7–10) to add adult providers, a persistent game DB, finalize EPG handling and complete Stash integration per the spec. 
- Avoid extra API calls and provide persistent overrides/lookup caching for game artwork lookups. 
- Make EPG full-lookup channel list configurable and ensure EPG titles are propagated to cover data. 
- Provide robust local Stash GraphQL lookup with host rewriting, retries and config options.

### Description
- Added three new adult providers: `stashdb` (`providers/stashdb.py`), `porndb` (`providers/porndb.py`) and `aebn` (`providers/aebn.py`) and wired them into the provider registry so adult category order follows `stash -> stashdb -> porndb -> aebn`.
- Implemented a persistent JSON game database (`providers/game_db.py`) at `/config/custom_components/smart_player/game_db.json` with `touch_title`, `get_title`, `update_title`, `lookup_failed`, `play_count`, `last_seen` and override fields, and integrated it into `IGDB`, `Steam` and `SteamGridDB` providers to short-circuit lookups and cache results.
- Finalized EPG path: made the full-lookup channel list configurable (`CONF_EPG_FULL_LOOKUP_CHANNELS`), propagated that list through `build_query` / `ArtworkQuery.epg_full_lookup_channels`, used it in scenario detection and avoided unnecessary API calls for private channels, and ensured `CoverData.title` contains the EPG program title when available.
- Added a full `Stash` provider (`providers/stash.py`) performing local GraphQL scene lookups, explicit `SCENE_BY_ID_QUERY` calls, screenshot-first priority, performer/studio fallback images, hostname/port rewrite logic, retry + timeout behavior, and config options (`CONF_STASH_URL`, `CONF_STASH_API_KEY`, `CONF_STASH_HOST_REWRITE`, `CONF_STASHDB_API_KEY`) surfaced in the config flow.
- Minor API/shape updates to carry `epg_full_lookup_channels` through `ArtworkQuery` and updated provider resolution logic to consult that set when deciding whether to skip TV lookups.

### Testing
- Ran Python byte-compile checks on modified/new modules with `python -m py_compile` for the following groups and they completed successfully: `providers/game_db.py providers/igdb.py providers/steamgriddb.py`; `__init__.py config_flow.py providers/base.py providers/query_builder.py providers/hierarchy.py providers/__init__.py`; and `providers/stash.py providers/stashdb.py providers/__init__.py config_flow.py const.py`.
- Config flow and constants additions were validated by successful module compilation and basic import-time checks; no runtime integration tests were run in this environment.
- Repo health check script output: `repo_health_check.sh not found` (the repository health script is not present in this workspace).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede601bcf88320a4910f0ded8209f3)